### PR TITLE
Support for terraform 0.15 (and lower)

### DIFF
--- a/pkg/brokerpak/manifest.go
+++ b/pkg/brokerpak/manifest.go
@@ -16,11 +16,14 @@
 package brokerpak
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/providers/tf"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/validation"
@@ -132,6 +135,11 @@ func (m *Manifest) Pack(base, dest string) error {
 		return err
 	}
 
+	log.Println("Packing terraform providers...")
+	if err := m.packProviders(dir, base); err != nil {
+		return err
+	}
+
 	log.Println("Creating archive:", dest)
 	return ziputil.Archive(dir, dest)
 }
@@ -156,6 +164,130 @@ func (m *Manifest) packBinaries(tmp string) error {
 			if err := getter.GetAny(platformPath, resource.Url(platform)); err != nil {
 				return err
 			}
+		}
+	}
+
+	return nil
+}
+
+func visitTfFolder(tfCur string, tfTmp string, providers *map[string]bool) filepath.WalkFunc {
+	return func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// ignore the .terraform folder
+		if path == tfCur+"/.terraform/" {
+			return nil
+		}
+
+		// split to kept path
+		s := strings.Split(path, tfCur+"/.terraform/")
+
+		// create folder if not exists in tmp folder
+		if info.IsDir() == true {
+			_, err := os.Stat(filepath.Join(tfTmp, s[1]))
+			if os.IsNotExist(err) {
+				err := os.MkdirAll(filepath.Join(tfTmp, s[1]), 0755)
+				if err != nil {
+					return fmt.Errorf("unable to create folder in tmp %v", err)
+				}
+			}
+		}
+
+		// file ?
+		if info.IsDir() == false {
+			tfBin := filepath.Base(path)
+
+			// just take in account file starting with terraform-provider
+			if strings.HasPrefix(tfBin, "terraform-provider-") == true {
+				exists := (*providers)[tfBin]
+				if exists == false {
+					log.Printf("\t%s", tfBin)
+					(*providers)[tfBin] = true
+
+					// move the provider binary in the temp folder
+					err := os.Rename(path, filepath.Join(tfTmp, s[1]))
+					if err != nil {
+						return fmt.Errorf("unable to move provider in tmp %v", err)
+					}
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func (m *Manifest) packProviders(tmp, base string) error {
+	err := os.MkdirAll(filepath.Join(tmp, "/terraform.d/providers"), 0755)
+	if err != nil {
+		return fmt.Errorf("unable to create terraform providers folder in tmp %v", err)
+	}
+
+	// search terraform folders in all services definitions
+	// duplicated folders are removed
+	tfDirs := make(map[string]bool)
+	for _, sd := range m.ServiceDefinitions {
+		defn := &tf.TfServiceDefinitionV1{}
+		if err := stream.Copy(stream.FromFile(base, sd), stream.ToYaml(defn)); err != nil {
+			return fmt.Errorf("couldn't parse %s: %v", sd, err)
+		}
+
+		if defn.ProvisionSettings.TemplateRef != "" {
+			tf_base := filepath.Dir(defn.ProvisionSettings.TemplateRef)
+			tfDirs[tf_base] = true
+		}
+
+		for _, ref := range defn.ProvisionSettings.TemplateRefs {
+			if ref != "" {
+				tfDirs[filepath.Dir(ref)] = true
+			}
+		}
+
+		if defn.BindSettings.TemplateRef != "" {
+			tf_base := filepath.Dir(defn.BindSettings.TemplateRef)
+			tfDirs[tf_base] = true
+		}
+
+		for _, ref := range defn.BindSettings.TemplateRefs {
+			if ref != "" {
+				tfDirs[filepath.Dir(ref)] = true
+			}
+		}
+
+	}
+
+	// execute terraform init on each folders
+	// duplicated providers are removed
+	providers := make(map[string]bool)
+	for _, platform := range m.Platforms {
+		for tfDir, _ := range tfDirs {
+			platformPath := filepath.Join(tmp, "bin", platform.Os, platform.Arch)
+
+			// exec terraform
+			tfDirPath := filepath.Join(base, tfDir)
+			cmd := exec.Command(platformPath+"/terraform", "init")
+			cmd.Dir = tfDirPath
+
+			var out bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.Stdout = &out
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+			if err != nil {
+				return fmt.Errorf(fmt.Sprint(err) + ": " + stderr.String())
+			}
+
+			// search plugins in the hidden terraform directory
+			err = filepath.Walk(tfDirPath+"/.terraform/", visitTfFolder(tfDirPath, tmp+"/terraform.d", &providers))
+			if err != nil {
+				return fmt.Errorf("walk on terraform failed: %v", err)
+			}
+
+			// clean up terraform folder
+			os.RemoveAll(tfDirPath + "/.terraform/")
 		}
 	}
 

--- a/pkg/brokerpak/manifest.go
+++ b/pkg/brokerpak/manifest.go
@@ -294,7 +294,7 @@ func (m *Manifest) packProviders(tmp, base string) error {
 	// duplicated providers are removed
 	providers := make(map[string]bool)
 	for _, platform := range m.Platforms {
-		for tfDir, _ := range tfDirs {
+		for tfDir := range tfDirs {
 			platformPath := filepath.Join(tmp, "bin", platform.Os, platform.Arch)
 
 			// terraform path

--- a/pkg/brokerpak/manifest.go
+++ b/pkg/brokerpak/manifest.go
@@ -175,14 +175,14 @@ func CopyProvider(sourcePath, destPath string) error {
 	// open source file
 	inputFile, err := os.Open(sourcePath)
 	if err != nil {
-		return fmt.Errorf("Couldn't open source file: %s", err)
+		return fmt.Errorf("couldn't open source file: %s", err)
 	}
 
 	// create a new one
 	outputFile, err := os.Create(destPath)
 	if err != nil {
 		inputFile.Close()
-		return fmt.Errorf("Couldn't open dest file: %s", err)
+		return fmt.Errorf("couldn't open dest file: %s", err)
 	}
 
 	// copy source content to destination
@@ -190,13 +190,13 @@ func CopyProvider(sourcePath, destPath string) error {
 	_, err = io.Copy(outputFile, inputFile)
 	inputFile.Close()
 	if err != nil {
-		return fmt.Errorf("Writing to dest file failed: %s", err)
+		return fmt.Errorf("writing to dest file failed: %s", err)
 	}
 
 	// change permission
 	err = os.Chmod(destPath, 0755)
 	if err != nil {
-		return fmt.Errorf("Change perm on dest file failed: %s", err)
+		return fmt.Errorf("change perm on dest file failed: %s", err)
 	}
 
 	return nil
@@ -217,7 +217,7 @@ func visitTfFolder(tfCur string, tfTmp string, providers *map[string]bool) filep
 		s := strings.Split(path, tfCur+"/.terraform/")
 
 		// create folder if not exists in tmp folder
-		if info.IsDir() == true {
+		if info.IsDir() {
 			_, err := os.Stat(filepath.Join(tfTmp, s[1]))
 			if os.IsNotExist(err) {
 				err := os.MkdirAll(filepath.Join(tfTmp, s[1]), 0755)
@@ -228,13 +228,13 @@ func visitTfFolder(tfCur string, tfTmp string, providers *map[string]bool) filep
 		}
 
 		// file ?
-		if info.IsDir() == false {
+		if !info.IsDir() {
 			tfBin := filepath.Base(path)
 
 			// just take in account file starting with terraform-provider
-			if strings.HasPrefix(tfBin, "terraform-provider-") == true {
+			if strings.HasPrefix(tfBin, "terraform-provider-") {
 				exists := (*providers)[tfBin]
-				if exists == false {
+				if !exists {
 					log.Printf("\t%s", tfBin)
 					(*providers)[tfBin] = true
 

--- a/pkg/brokerpak/reader.go
+++ b/pkg/brokerpak/reader.go
@@ -119,6 +119,13 @@ func (pak *BrokerPakReader) ExtractPlatformBins(destination string) error {
 	return ziputil.Extract(&pak.contents.Reader, bindir, destination)
 }
 
+// ExtractProvidersBins extracts the providers binaries to the given destination.
+func (pak *BrokerPakReader) ExtractProvidersBins(destination string) error {
+	// extract terraform providers from pack
+	bindir := ziputil.Join("terraform.d")
+	return ziputil.Extract(&pak.contents.Reader, bindir, destination)
+}
+
 // OpenBrokerPak opens the file at the given path as a BrokerPakReader.
 func OpenBrokerPak(pakPath string) (*BrokerPakReader, error) {
 	rc, err := zip.OpenReader(pakPath)

--- a/pkg/providers/tf/wrapper/workspace.go
+++ b/pkg/providers/tf/wrapper/workspace.go
@@ -439,7 +439,8 @@ func CustomTerraformExecutor(tfBinaryPath, tfPluginDir string, wrapped Terraform
 		subCommandArgs := c.Args[2:]
 
 		if subCommand == "init" {
-			subCommandArgs = append([]string{"-get-plugins=false", fmt.Sprintf("-plugin-dir=%s", tfPluginDir)}, subCommandArgs...)
+			///subCommandArgs = append([]string{"-get-plugins=false", fmt.Sprintf("-plugin-dir=%s", tfPluginDir)}, subCommandArgs...)
+			subCommandArgs = append([]string{fmt.Sprintf("-plugin-dir=%s", tfPluginDir)}, subCommandArgs...)
 		}
 
 		allArgs := append([]string{subCommand}, subCommandArgs...)

--- a/pkg/providers/tf/wrapper/workspace_test.go
+++ b/pkg/providers/tf/wrapper/workspace_test.go
@@ -217,7 +217,7 @@ func TestCustomTerraformExecutor(t *testing.T) {
 		},
 		"init": {
 			Input:    exec.Command("terraform", "init", "-no-color"),
-			Expected: exec.Command(customBinary, "init", "-get-plugins=false", pluginsFlag, "-no-color"),
+			Expected: exec.Command(customBinary, "init", pluginsFlag, "-no-color"),
 		},
 		"import": {
 			Input:    exec.Command("terraform", "import", "-no-color", "tf.resource", "iaas-resource"),


### PR DESCRIPTION
Hi,  

This is a proposal to support terraform > 0.12 #99 . Below some explanation.

- With this PR, it's not longer necessary to declare terraform binaries in the manifest yaml. Just the binary of terraform must be declared.

```
platforms:
- os: linux
  arch: amd64
terraform_binaries:
- name: terraform
  version: 0.15.0
  source: https://releases.hashicorp.com/terraform/0.15.0/terraform_0.15.0_linux_amd64.zip
```

- During the build of the brokerpak, terraform providers to be integrated are automatically detected and downloaded.
Each service is inspected to get terraform files and get providers used.

```
2021/04/26 19:29:50 Packing terraform providers...
2021/04/26 19:29:54     terraform-provider-null_v3.1.0_x5
```

Providers binaries are saved in the same way of the terraform init command. In the folder "plugins" for terraform 0.12 or in the folder "providers" for terraform > 0.12.

- Finally plugins are loaded as usual with the -plugin-dir option.

With this approch, terraform 0.12 and greater are supported.

Denis