### PR TITLE
feat: generate default plan if none is specified

### DIFF
--- a/docs/brokerpak-specification.md
+++ b/docs/brokerpak-specification.md
@@ -155,6 +155,10 @@ A service plan in a human-friendly format that can be converted into an OSB comp
 | provision_overrides | map of string:any | Constant values to be overwritten for the provision calls. |
 | bind_overrides | map of string:aany |  Constant values to be overwritten for the bind calls. |
 
+Note that if no plans are specified, a default plan will be generated named `default`.
+The ID of the default plan is derived from the name and ID of the service, and will change
+if either or those change.
+
 #### Action object
 
 The Action object contains a Terraform template to execute as part of a

--- a/integrationtest/brokerpaks_test.go
+++ b/integrationtest/brokerpaks_test.go
@@ -2,44 +2,34 @@ package integrationtest_test
 
 import (
 	"os"
-	"os/exec"
 	"path"
 	"time"
 
+	"github.com/cloudfoundry-incubator/cloud-service-broker/integrationtest/helper"
 	"github.com/cloudfoundry-incubator/cloud-service-broker/internal/zippy"
-	. "github.com/onsi/gomega/gbytes"
-	. "github.com/onsi/gomega/gexec"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gbytes"
+	. "github.com/onsi/gomega/gexec"
 )
 
 var _ = Describe("Brokerpaks", func() {
 	var (
-		originalDir string
-		fixturesDir string
-		workDir     string
+		originalDir helper.Original
 	)
 
 	BeforeEach(func() {
-		var err error
-		originalDir, err = os.Getwd()
-		Expect(err).NotTo(HaveOccurred())
-		fixturesDir = path.Join(originalDir, "fixtures")
-
-		workDir = GinkgoT().TempDir()
-		err = os.Chdir(workDir)
-		Expect(err).NotTo(HaveOccurred())
+		originalDir = helper.OriginalDir()
 	})
 
 	AfterEach(func() {
-		err := os.Chdir(originalDir)
-		Expect(err).NotTo(HaveOccurred())
+		originalDir.Return()
 	})
 
 	When("duplicate plan IDs", func() {
 		It("fails to build", func() {
-			command := exec.Command(csb, "pak", "build", path.Join(fixturesDir, "brokerpak-with-duplicate-plan-id"))
+			testLab := helper.NewTestLab(csb)
+			command := testLab.BuildBrokerpakCommand(string(originalDir), "fixtures", "brokerpak-with-duplicate-plan-id")
 			session, err := Start(command, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
 			session.Wait(10 * time.Minute)
@@ -50,15 +40,15 @@ var _ = Describe("Brokerpaks", func() {
 	})
 
 	Describe("file inclusion", func() {
-		BeforeEach(func() {
-			err := os.WriteFile(path.Join(workDir, "extrafile.sh"), []byte("echo hello"), 0777)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
 		It("includes the files", func() {
-			brokerpakPath := path.Join(workDir, "fake-brokerpak-0.1.0.brokerpak")
+			testLab := helper.NewTestLab(csb)
+
+			err := os.WriteFile(path.Join(testLab.Dir, "extrafile.sh"), []byte("echo hello"), 0777)
+			Expect(err).NotTo(HaveOccurred())
+
+			brokerpakPath := path.Join(testLab.Dir, "fake-brokerpak-0.1.0.brokerpak")
 			By("building the brokerpak", func() {
-				command := exec.Command(csb, "pak", "build", path.Join(fixturesDir, "brokerpak-file-inclusion"))
+				command := testLab.BuildBrokerpakCommand(string(originalDir), "fixtures", "brokerpak-file-inclusion")
 				session, err := Start(command, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 				session.Wait(10 * time.Minute)
@@ -68,7 +58,7 @@ var _ = Describe("Brokerpaks", func() {
 				Expect(brokerpakPath).To(BeAnExistingFile())
 			})
 
-			extractedPath := path.Join(workDir, "extracted")
+			extractedPath := GinkgoT().TempDir()
 			By("unzipping the brokerpak", func() {
 				zr, err := zippy.Open(brokerpakPath)
 				Expect(err).NotTo(HaveOccurred())

--- a/integrationtest/catalog_test.go
+++ b/integrationtest/catalog_test.go
@@ -2,110 +2,55 @@ package integrationtest_test
 
 import (
 	"fmt"
-	"os"
-	"os/exec"
-	"path"
 	"time"
 
+	"github.com/cloudfoundry-incubator/cloud-service-broker/integrationtest/helper"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gbytes"
 	. "github.com/onsi/gomega/gexec"
-	"github.com/pborman/uuid"
 	_ "gorm.io/driver/sqlite"
 )
 
 var _ = Describe("Catalog", func() {
+	const userProvidedPlan = `[{"name": "user-plan","id":"8b52a460-b246-11eb-a8f5-d349948e2480"}]`
+
 	var (
-		originalDir      string
-		fixturesDir      string
-		workDir          string
-		brokerPort       int
-		brokerUsername   string
-		brokerPassword   string
-		brokerSession    *Session
-		databaseFile     string
-		runBrokerCommand *exec.Cmd
+		originalDir helper.Original
+		testLab     *helper.TestLab
 	)
 
 	BeforeEach(func() {
-		var err error
-		originalDir, err = os.Getwd()
-		Expect(err).NotTo(HaveOccurred())
-		fixturesDir = path.Join(originalDir, "fixtures", "brokerpak-for-catalog-test")
-
-		workDir = GinkgoT().TempDir()
-		err = os.Chdir(workDir)
-		Expect(err).NotTo(HaveOccurred())
-
-		buildBrokerpakCommand := exec.Command(csb, "pak", "build", fixturesDir)
-		session, err := Start(buildBrokerpakCommand, GinkgoWriter, GinkgoWriter)
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(session, 10*time.Minute).Should(Exit(0))
-
-		brokerUsername = uuid.New()
-		brokerPassword = uuid.New()
-		brokerPort = freePort()
-		databaseFile = path.Join(workDir, "databaseFile.dat")
-		runBrokerCommand = exec.Command(csb, "serve")
+		originalDir = helper.OriginalDir()
+		testLab = helper.NewTestLab(csb)
+		testLab.BuildBrokerpak(string(originalDir), "fixtures", "brokerpak-for-catalog-test")
 	})
 
 	AfterEach(func() {
-		brokerSession.Terminate()
-
-		err := os.Chdir(originalDir)
-		Expect(err).NotTo(HaveOccurred())
+		originalDir.Return()
 	})
 
 	When("a service offering has duplicate plan IDs", func() {
-		JustBeforeEach(func() {
-			const userProvidedPlan = `[{"name": "user-plan","id":"8b52a460-b246-11eb-a8f5-d349948e2480"}]`
-			runBrokerCommand.Env = append(
-				os.Environ(),
-				"CSB_LISTENER_HOST=localhost",
-				"DB_TYPE=sqlite3",
-				fmt.Sprintf("DB_PATH=%s", databaseFile),
-				fmt.Sprintf("PORT=%d", brokerPort),
-				fmt.Sprintf("SECURITY_USER_NAME=%s", brokerUsername),
-				fmt.Sprintf("SECURITY_USER_PASSWORD=%s", brokerPassword),
-				fmt.Sprintf("GSB_SERVICE_ALPHA_SERVICE_PLANS=%s", userProvidedPlan),
-			)
-		})
-
 		It("fails to start", func() {
-			var err error
-			brokerSession, err = Start(runBrokerCommand, GinkgoWriter, GinkgoWriter)
+			cmd := testLab.StartBrokerCommand(fmt.Sprintf("GSB_SERVICE_ALPHA_SERVICE_PLANS=%s", userProvidedPlan))
+			session, err := Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
-			brokerSession.Wait(time.Minute)
+			session.Wait(time.Minute)
 
-			Expect(brokerSession.ExitCode()).NotTo(BeZero())
-			Expect(brokerSession.Err).To(Say("duplicated value, must be unique: 8b52a460-b246-11eb-a8f5-d349948e2480: Plans\\[1\\].Id\n"))
+			Expect(session.ExitCode()).NotTo(BeZero())
+			Expect(session.Err).To(Say("duplicated value, must be unique: 8b52a460-b246-11eb-a8f5-d349948e2480: Plans\\[1\\].Id\n"))
 		})
 	})
 
 	When("two service offerings have duplicate plan IDs", func() {
-		JustBeforeEach(func() {
-			const userProvidedPlan = `[{"name": "user-plan","id":"8b52a460-b246-11eb-a8f5-d349948e2480"}]`
-			runBrokerCommand.Env = append(
-				os.Environ(),
-				"CSB_LISTENER_HOST=localhost",
-				"DB_TYPE=sqlite3",
-				fmt.Sprintf("DB_PATH=%s", databaseFile),
-				fmt.Sprintf("PORT=%d", brokerPort),
-				fmt.Sprintf("SECURITY_USER_NAME=%s", brokerUsername),
-				fmt.Sprintf("SECURITY_USER_PASSWORD=%s", brokerPassword),
-				fmt.Sprintf("GSB_SERVICE_BETA_SERVICE_PLANS=%s", userProvidedPlan),
-			)
-		})
-
 		It("fails to start", func() {
-			var err error
-			brokerSession, err = Start(runBrokerCommand, GinkgoWriter, GinkgoWriter)
+			cmd := testLab.StartBrokerCommand(fmt.Sprintf("GSB_SERVICE_BETA_SERVICE_PLANS=%s", userProvidedPlan))
+			session, err := Start(cmd, GinkgoWriter, GinkgoWriter)
 			Expect(err).NotTo(HaveOccurred())
-			brokerSession.Wait(10 * time.Minute)
+			session.Wait(time.Minute)
 
-			Expect(brokerSession.ExitCode()).NotTo(BeZero())
-			Expect(brokerSession.Err).To(Say("duplicated value, must be unique: 8b52a460-b246-11eb-a8f5-d349948e2480: services\\[1\\].Plans\\[1\\].Id\n"))
+			Expect(session.ExitCode()).NotTo(BeZero())
+			Expect(session.Err).To(Say("duplicated value, must be unique: 8b52a460-b246-11eb-a8f5-d349948e2480: services\\[1\\].Plans\\[1\\].Id\n"))
 		})
 	})
 })

--- a/integrationtest/fixtures/brokerpak-without-a-plan/fake-service.yml
+++ b/integrationtest/fixtures/brokerpak-without-a-plan/fake-service.yml
@@ -1,0 +1,24 @@
+version: 1
+name: alpha-service
+
+id: 76c5725c-b246-11eb-871f-ffc97563fbd0
+description: description
+display_name: Alpha Service
+image_url: https://example.com/icon.jpg
+documentation_url: https://example.com
+support_url: https://example.com/support.html
+plans:
+provision:
+  user_inputs:
+    - field_name: foo
+      type: number
+      default: 42
+      details: Answer
+    - field_name: bar
+      type: string
+      default: hello
+      details: Greeting
+    - field_name: baz
+      type: boolean
+      details: Yes or no
+      default: true

--- a/integrationtest/fixtures/brokerpak-without-a-plan/manifest.yml
+++ b/integrationtest/fixtures/brokerpak-without-a-plan/manifest.yml
@@ -1,0 +1,16 @@
+packversion: 1
+name: fake-brokerpak
+version: 0.1.0
+metadata:
+  author: noone@nowhere.com
+platforms:
+- os: linux
+  arch: amd64
+- os: darwin
+  arch: amd64
+terraform_binaries:
+- name: terraform
+  version: 0.12.21
+  source: https://github.com/hashicorp/terraform/archive/v0.12.21.zip
+service_definitions:
+  - fake-service.yml

--- a/integrationtest/helper/build_brokerpak.go
+++ b/integrationtest/helper/build_brokerpak.go
@@ -1,0 +1,21 @@
+package helper
+
+import (
+	"os/exec"
+	"path"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+func (tl *TestLab) BuildBrokerpakCommand(paths ...string) *exec.Cmd {
+	return exec.Command(tl.csb, "pak", "build", path.Join(paths...))
+}
+
+func (tl *TestLab) BuildBrokerpak(paths ...string) {
+	session, err := gexec.Start(tl.BuildBrokerpakCommand(paths...), ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Eventually(session, 10*time.Minute).Should(gexec.Exit(0))
+}

--- a/integrationtest/helper/client.go
+++ b/integrationtest/helper/client.go
@@ -1,0 +1,12 @@
+package helper
+
+import (
+	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/client"
+	"github.com/onsi/gomega"
+)
+
+func (tl *TestLab) Client() *client.Client {
+	brokerClient, err := client.New(tl.username, tl.password, "localhost", tl.port)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	return brokerClient
+}

--- a/integrationtest/helper/free_port.go
+++ b/integrationtest/helper/free_port.go
@@ -1,0 +1,14 @@
+package helper
+
+import (
+	"net"
+
+	"github.com/onsi/gomega"
+)
+
+func freePort() int {
+	listener, err := net.Listen("tcp", "localhost:0")
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}

--- a/integrationtest/helper/original_dir.go
+++ b/integrationtest/helper/original_dir.go
@@ -1,0 +1,20 @@
+package helper
+
+import (
+	"os"
+
+	"github.com/onsi/gomega"
+)
+
+func OriginalDir() Original {
+	dir, err := os.Getwd()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	return Original(dir)
+}
+
+type Original string
+
+func (o Original) Return() {
+	err := os.Chdir(string(o))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+}

--- a/integrationtest/helper/start_broker.go
+++ b/integrationtest/helper/start_broker.go
@@ -1,0 +1,40 @@
+package helper
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+func (tl *TestLab) StartBrokerCommand(env ...string) *exec.Cmd {
+	cmd := exec.Command(tl.csb, "serve")
+	cmd.Env = append(
+		os.Environ(),
+		"CSB_LISTENER_HOST=localhost",
+		"DB_TYPE=sqlite3",
+		fmt.Sprintf("DB_PATH=%s", tl.DatabaseFile),
+		fmt.Sprintf("PORT=%d", tl.port),
+		fmt.Sprintf("SECURITY_USER_NAME=%s", tl.username),
+		fmt.Sprintf("SECURITY_USER_PASSWORD=%s", tl.password),
+	)
+	cmd.Env = append(cmd.Env, env...)
+
+	return cmd
+}
+
+func (tl *TestLab) StartBrokerSession(env ...string) *gexec.Session {
+	cmd := tl.StartBrokerCommand(env...)
+	session, err := gexec.Start(cmd, ginkgo.GinkgoWriter, ginkgo.GinkgoWriter)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	return session
+}
+
+func (tl *TestLab) StartBroker(env ...string) *gexec.Session {
+	session := tl.StartBrokerSession(env...)
+	waitForBrokerToStart(tl.port)
+	return session
+}

--- a/integrationtest/helper/test_lab.go
+++ b/integrationtest/helper/test_lab.go
@@ -1,0 +1,35 @@
+package helper
+
+import (
+	"os"
+	"path"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"github.com/pborman/uuid"
+)
+
+func NewTestLab(csb string) *TestLab {
+	tmpDir := ginkgo.GinkgoT().TempDir()
+
+	err := os.Chdir(tmpDir)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return &TestLab{
+		csb:          csb,
+		Dir:          tmpDir,
+		port:         freePort(),
+		username:     uuid.New(),
+		password:     uuid.New(),
+		DatabaseFile: path.Join(tmpDir, "DatabaseFile.dat"),
+	}
+}
+
+type TestLab struct {
+	Dir          string
+	csb          string
+	port         int
+	username     string
+	password     string
+	DatabaseFile string
+}

--- a/integrationtest/helper/wait_for_start.go
+++ b/integrationtest/helper/wait_for_start.go
@@ -1,0 +1,17 @@
+package helper
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/onsi/gomega"
+)
+
+func waitForBrokerToStart(port int) {
+	ping := func() (*http.Response, error) {
+		return http.Head(fmt.Sprintf("http://localhost:%d", port))
+	}
+
+	gomega.Eventually(ping, 30*time.Second).Should(gomega.HaveHTTPStatus(http.StatusOK))
+}

--- a/integrationtest/integrationtest_suite_test.go
+++ b/integrationtest/integrationtest_suite_test.go
@@ -1,11 +1,7 @@
 package integrationtest_test
 
 import (
-	"fmt"
-	"net"
-	"net/http"
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,21 +31,6 @@ var _ = SynchronizedAfterSuite(
 	func() {},
 	func() { CleanupBuildArtifacts() },
 )
-
-func freePort() int {
-	listener, err := net.Listen("tcp", "localhost:0")
-	Expect(err).NotTo(HaveOccurred())
-	defer listener.Close()
-	return listener.Addr().(*net.TCPAddr).Port
-}
-
-func waitForBrokerToStart(port int) {
-	ping := func() (*http.Response, error) {
-		return http.Head(fmt.Sprintf("http://localhost:%d", port))
-	}
-
-	Eventually(ping, 30*time.Second).Should(HaveHTTPStatus(http.StatusOK))
-}
 
 func requestID() string {
 	return uuid.New()

--- a/integrationtest/planless_test.go
+++ b/integrationtest/planless_test.go
@@ -1,0 +1,87 @@
+package integrationtest_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/cloudfoundry-incubator/cloud-service-broker/integrationtest/helper"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+)
+
+var _ = Describe("Plan-less", func() {
+	var (
+		originalDir helper.Original
+		testLab     *helper.TestLab
+		session     *Session
+	)
+
+	BeforeEach(func() {
+		originalDir = helper.OriginalDir()
+		testLab = helper.NewTestLab(csb)
+	})
+
+	AfterEach(func() {
+		session.Terminate()
+		originalDir.Return()
+	})
+
+	It("creates a default plan", func() {
+		type catalog struct {
+			Services []domain.Service `json:"services"`
+		}
+
+		var planID string
+
+		testLab.BuildBrokerpak(string(originalDir), "fixtures", "brokerpak-without-a-plan")
+		session = testLab.StartBroker()
+
+		By("checking the catalog response", func() {
+			response := testLab.Client().Catalog(requestID())
+			Expect(response.Error).NotTo(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+			var receiver catalog
+			Expect(json.Unmarshal(response.ResponseBody, &receiver)).NotTo(HaveOccurred())
+			Expect(receiver.Services).To(HaveLen(1))
+			Expect(receiver.Services[0].Plans).To(HaveLen(1))
+			Expect(receiver.Services[0].Plans[0].Name).To(Equal("default"))
+			planID = receiver.Services[0].Plans[0].ID
+			Expect(planID).To(HaveLen(36))
+		})
+
+		By("checking that the UUID does not change", func() {
+			session.Terminate()
+			session = testLab.StartBroker()
+
+			response := testLab.Client().Catalog(requestID())
+			Expect(response.Error).NotTo(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+			var receiver catalog
+			Expect(json.Unmarshal(response.ResponseBody, &receiver)).NotTo(HaveOccurred())
+			Expect(receiver.Services[0].Plans[0].ID).To(Equal(planID))
+		})
+
+		By("checking that the default plan evaporates if there is a user-defined plan", func() {
+			const userProvidedPlan = `[{"name": "user-plan","id":"8b52a460-b246-11eb-a8f5-d349948e2480"}]`
+
+			session.Terminate()
+			session = testLab.StartBroker(fmt.Sprintf("GSB_SERVICE_ALPHA_SERVICE_PLANS=%s", userProvidedPlan))
+
+			response := testLab.Client().Catalog(requestID())
+			Expect(response.Error).NotTo(HaveOccurred())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+			var receiver catalog
+			Expect(json.Unmarshal(response.ResponseBody, &receiver)).NotTo(HaveOccurred())
+			Expect(receiver.Services).To(HaveLen(1))
+			Expect(receiver.Services[0].Plans).To(HaveLen(1))
+			Expect(receiver.Services[0].Plans[0].Name).To(Equal("user-plan"))
+			Expect(receiver.Services[0].Plans[0].ID).To(Equal("8b52a460-b246-11eb-a8f5-d349948e2480"))
+		})
+	})
+})

--- a/integrationtest/subsume_test.go
+++ b/integrationtest/subsume_test.go
@@ -2,92 +2,47 @@ package integrationtest_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"os"
-	"os/exec"
-	"path"
 	"time"
 
-	"github.com/pivotal-cf/brokerapi/v8/domain"
-
-	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/client"
+	"github.com/cloudfoundry-incubator/cloud-service-broker/integrationtest/helper"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 	"github.com/pborman/uuid"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
 	_ "gorm.io/driver/sqlite"
 )
 
 var _ = Describe("Subsume", func() {
-
 	var (
-		originalDir         string
-		fixturesDir         string
-		workDir             string
-		brokerPort          int
-		brokerUsername      string
-		brokerPassword      string
-		brokerSession       *Session
-		brokerClient        *client.Client
-		databaseFile        string
-		serviceInstanceGUID string
+		originalDir helper.Original
+		testLab     *helper.TestLab
+		session     *Session
 	)
 
-	JustBeforeEach(func() {
-		var err error
-		originalDir, err = os.Getwd()
-		Expect(err).NotTo(HaveOccurred())
-		fixturesDir = path.Join(originalDir, "fixtures", "brokerpak-for-subsume-cancel")
-
-		workDir = GinkgoT().TempDir()
-		err = os.Chdir(workDir)
-		Expect(err).NotTo(HaveOccurred())
-
-		buildBrokerpakCommand := exec.Command(csb, "pak", "build", fixturesDir)
-		session, err := Start(buildBrokerpakCommand, GinkgoWriter, GinkgoWriter)
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(session, 10*time.Minute).Should(Exit(0))
-
-		brokerUsername = uuid.New()
-		brokerPassword = uuid.New()
-		brokerPort = freePort()
-		databaseFile = path.Join(workDir, "databaseFile.dat")
-		runBrokerCommand := exec.Command(csb, "serve")
-		runBrokerCommand.Env = append(
-			os.Environ(),
-			"CSB_LISTENER_HOST=localhost",
-			"DB_TYPE=sqlite3",
-			fmt.Sprintf("DB_PATH=%s", databaseFile),
-			fmt.Sprintf("PORT=%d", brokerPort),
-			fmt.Sprintf("SECURITY_USER_NAME=%s", brokerUsername),
-			fmt.Sprintf("SECURITY_USER_PASSWORD=%s", brokerPassword),
-		)
-		brokerSession, err = Start(runBrokerCommand, GinkgoWriter, GinkgoWriter)
-		Expect(err).NotTo(HaveOccurred())
-		waitForBrokerToStart(brokerPort)
-
-		brokerClient, err = client.New(brokerUsername, brokerPassword, "localhost", brokerPort)
-		Expect(err).NotTo(HaveOccurred())
+	BeforeEach(func() {
+		originalDir = helper.OriginalDir()
+		testLab = helper.NewTestLab(csb)
+		testLab.BuildBrokerpak(string(originalDir), "fixtures", "brokerpak-for-subsume-cancel")
+		session = testLab.StartBroker()
 	})
 
 	AfterEach(func() {
-		brokerSession.Terminate()
-
-		err := os.Chdir(originalDir)
-		Expect(err).NotTo(HaveOccurred())
+		session.Terminate()
+		originalDir.Return()
 	})
 
 	It("can subsume a resource", func() {
 		const serviceOfferingGUID = "547cad88-fa93-11eb-9f44-97feefe52547"
 		const servicePlanGUID = "59624c68-fa93-11eb-9081-e79b0e1ab5ae"
-		serviceInstanceGUID = uuid.New()
-		provisionResponse := brokerClient.Provision(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, uuid.New(), []byte(`{"value":"a97fd57a-fa94-11eb-8256-930255607a99"}`))
+		serviceInstanceGUID := uuid.New()
+		provisionResponse := testLab.Client().Provision(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, uuid.New(), []byte(`{"value":"a97fd57a-fa94-11eb-8256-930255607a99"}`))
 		Expect(provisionResponse.Error).NotTo(HaveOccurred())
 		Expect(provisionResponse.StatusCode).To(Equal(http.StatusAccepted), string(provisionResponse.ResponseBody))
 
 		Eventually(func() bool {
-			lastOperationResponse := brokerClient.LastOperation(serviceInstanceGUID, requestID())
+			lastOperationResponse := testLab.Client().LastOperation(serviceInstanceGUID, requestID())
 			Expect(lastOperationResponse.Error).NotTo(HaveOccurred())
 			Expect(lastOperationResponse.StatusCode).To(Equal(http.StatusOK))
 			var receiver domain.LastOperation
@@ -102,14 +57,14 @@ var _ = Describe("Subsume", func() {
 		// This test relies on a behaviour in the random string resource where it gets re-created after being imported
 		const serviceOfferingGUID = "76c5725c-b246-11eb-871f-ffc97563fbd0"
 		const servicePlanGUID = "8b52a460-b246-11eb-a8f5-d349948e2481"
-		serviceInstanceGUID = uuid.New()
-		provisionResponse := brokerClient.Provision(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, uuid.New(), []byte(`{"value":"thisisnotrandomatall"}`))
+		serviceInstanceGUID := uuid.New()
+		provisionResponse := testLab.Client().Provision(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, uuid.New(), []byte(`{"value":"thisisnotrandomatall"}`))
 		Expect(provisionResponse.Error).NotTo(HaveOccurred())
 		Expect(provisionResponse.StatusCode).To(Equal(http.StatusAccepted), string(provisionResponse.ResponseBody))
 
 		var receiver domain.LastOperation
 		Eventually(func() bool {
-			lastOperationResponse := brokerClient.LastOperation(serviceInstanceGUID, requestID())
+			lastOperationResponse := testLab.Client().LastOperation(serviceInstanceGUID, requestID())
 			Expect(lastOperationResponse.Error).NotTo(HaveOccurred())
 			Expect(lastOperationResponse.StatusCode).To(Equal(http.StatusOK))
 			err := json.Unmarshal(lastOperationResponse.ResponseBody, &receiver)

--- a/integrationtest/terraform_0.12_test.go
+++ b/integrationtest/terraform_0.12_test.go
@@ -2,91 +2,48 @@ package integrationtest_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"os"
-	"os/exec"
-	"path"
 	"time"
 
-	"github.com/pivotal-cf/brokerapi/v8/domain"
-
-	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/client"
+	"github.com/cloudfoundry-incubator/cloud-service-broker/integrationtest/helper"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 	"github.com/pborman/uuid"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
 	_ "gorm.io/driver/sqlite"
 )
 
 var _ = Describe("Terraform 0.12", func() {
 	var (
-		originalDir         string
-		fixturesDir         string
-		workDir             string
-		brokerPort          int
-		brokerUsername      string
-		brokerPassword      string
-		brokerSession       *Session
-		brokerClient        *client.Client
-		databaseFile        string
-		serviceInstanceGUID string
+		originalDir helper.Original
+		testLab     *helper.TestLab
+		session     *Session
 	)
 
-	JustBeforeEach(func() {
-		var err error
-		originalDir, err = os.Getwd()
-		Expect(err).NotTo(HaveOccurred())
-		fixturesDir = path.Join(originalDir, "fixtures", "brokerpak-terraform-0.12")
+	BeforeEach(func() {
+		originalDir = helper.OriginalDir()
+		testLab = helper.NewTestLab(csb)
+		testLab.BuildBrokerpak(string(originalDir), "fixtures", "brokerpak-terraform-0.12")
 
-		workDir = GinkgoT().TempDir()
-		err = os.Chdir(workDir)
-		Expect(err).NotTo(HaveOccurred())
-
-		buildBrokerpakCommand := exec.Command(csb, "pak", "build", fixturesDir)
-		session, err := Start(buildBrokerpakCommand, GinkgoWriter, GinkgoWriter)
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(session, 10*time.Minute).Should(Exit(0))
-
-		brokerUsername = uuid.New()
-		brokerPassword = uuid.New()
-		brokerPort = freePort()
-		databaseFile = path.Join(workDir, "databaseFile.dat")
-		runBrokerCommand := exec.Command(csb, "serve")
-		runBrokerCommand.Env = append(
-			os.Environ(),
-			"CSB_LISTENER_HOST=localhost",
-			"DB_TYPE=sqlite3",
-			fmt.Sprintf("DB_PATH=%s", databaseFile),
-			fmt.Sprintf("PORT=%d", brokerPort),
-			fmt.Sprintf("SECURITY_USER_NAME=%s", brokerUsername),
-			fmt.Sprintf("SECURITY_USER_PASSWORD=%s", brokerPassword),
-		)
-		brokerSession, err = Start(runBrokerCommand, GinkgoWriter, GinkgoWriter)
-		Expect(err).NotTo(HaveOccurred())
-		waitForBrokerToStart(brokerPort)
-
-		brokerClient, err = client.New(brokerUsername, brokerPassword, "localhost", brokerPort)
-		Expect(err).NotTo(HaveOccurred())
+		session = testLab.StartBroker()
 	})
 
 	AfterEach(func() {
-		brokerSession.Terminate()
-
-		err := os.Chdir(originalDir)
-		Expect(err).NotTo(HaveOccurred())
+		session.Terminate()
+		originalDir.Return()
 	})
 
 	It("can provision using this Terraform version", func() {
 		const serviceOfferingGUID = "df2c1512-3013-11ec-8704-2fbfa9c8a802"
 		const servicePlanGUID = "e59773ce-3013-11ec-9bbb-9376b4f72d14"
-		serviceInstanceGUID = uuid.New()
-		provisionResponse := brokerClient.Provision(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, uuid.New(), nil)
+		serviceInstanceGUID := uuid.New()
+		provisionResponse := testLab.Client().Provision(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, uuid.New(), nil)
 		Expect(provisionResponse.Error).NotTo(HaveOccurred())
 		Expect(provisionResponse.StatusCode).To(Equal(http.StatusAccepted))
 
 		Eventually(func() bool {
-			lastOperationResponse := brokerClient.LastOperation(serviceInstanceGUID, requestID())
+			lastOperationResponse := testLab.Client().LastOperation(serviceInstanceGUID, requestID())
 			Expect(lastOperationResponse.Error).NotTo(HaveOccurred())
 			Expect(lastOperationResponse.StatusCode).To(Equal(http.StatusOK))
 			var receiver domain.LastOperation

--- a/integrationtest/terraform_0.13_test.go
+++ b/integrationtest/terraform_0.13_test.go
@@ -2,91 +2,47 @@ package integrationtest_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
-	"os"
-	"os/exec"
-	"path"
 	"time"
 
-	"github.com/pivotal-cf/brokerapi/v8/domain"
-
-	"github.com/cloudfoundry-incubator/cloud-service-broker/pkg/client"
+	"github.com/cloudfoundry-incubator/cloud-service-broker/integrationtest/helper"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 	"github.com/pborman/uuid"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
 	_ "gorm.io/driver/sqlite"
 )
 
 var _ = Describe("Terraform 0.13", func() {
 	var (
-		originalDir         string
-		fixturesDir         string
-		workDir             string
-		brokerPort          int
-		brokerUsername      string
-		brokerPassword      string
-		brokerSession       *Session
-		brokerClient        *client.Client
-		databaseFile        string
-		serviceInstanceGUID string
+		originalDir helper.Original
+		testLab     *helper.TestLab
+		session     *Session
 	)
 
-	JustBeforeEach(func() {
-		var err error
-		originalDir, err = os.Getwd()
-		Expect(err).NotTo(HaveOccurred())
-		fixturesDir = path.Join(originalDir, "fixtures", "brokerpak-terraform-0.13")
-
-		workDir = GinkgoT().TempDir()
-		err = os.Chdir(workDir)
-		Expect(err).NotTo(HaveOccurred())
-
-		buildBrokerpakCommand := exec.Command(csb, "pak", "build", fixturesDir)
-		session, err := Start(buildBrokerpakCommand, GinkgoWriter, GinkgoWriter)
-		Expect(err).NotTo(HaveOccurred())
-		Eventually(session, 10*time.Minute).Should(Exit(0))
-
-		brokerUsername = uuid.New()
-		brokerPassword = uuid.New()
-		brokerPort = freePort()
-		databaseFile = path.Join(workDir, "databaseFile.dat")
-		runBrokerCommand := exec.Command(csb, "serve")
-		runBrokerCommand.Env = append(
-			os.Environ(),
-			"CSB_LISTENER_HOST=localhost",
-			"DB_TYPE=sqlite3",
-			fmt.Sprintf("DB_PATH=%s", databaseFile),
-			fmt.Sprintf("PORT=%d", brokerPort),
-			fmt.Sprintf("SECURITY_USER_NAME=%s", brokerUsername),
-			fmt.Sprintf("SECURITY_USER_PASSWORD=%s", brokerPassword),
-		)
-		brokerSession, err = Start(runBrokerCommand, GinkgoWriter, GinkgoWriter)
-		Expect(err).NotTo(HaveOccurred())
-		waitForBrokerToStart(brokerPort)
-
-		brokerClient, err = client.New(brokerUsername, brokerPassword, "localhost", brokerPort)
-		Expect(err).NotTo(HaveOccurred())
+	BeforeEach(func() {
+		originalDir = helper.OriginalDir()
+		testLab = helper.NewTestLab(csb)
+		testLab.BuildBrokerpak(string(originalDir), "fixtures", "brokerpak-terraform-0.13")
+		session = testLab.StartBroker()
 	})
 
 	AfterEach(func() {
-		brokerSession.Terminate()
-
-		err := os.Chdir(originalDir)
-		Expect(err).NotTo(HaveOccurred())
+		session.Terminate()
+		originalDir.Return()
 	})
 
 	It("can provision using this Terraform version", func() {
 		const serviceOfferingGUID = "29d4119f-2e88-4e85-8c40-7360f3d9c695"
 		const servicePlanGUID = "056c052c-e7b0-4c8e-8d6b-18616e06a7ac"
-		serviceInstanceGUID = uuid.New()
-		provisionResponse := brokerClient.Provision(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, uuid.New(), nil)
+		serviceInstanceGUID := uuid.New()
+		provisionResponse := testLab.Client().Provision(serviceInstanceGUID, serviceOfferingGUID, servicePlanGUID, uuid.New(), nil)
 		Expect(provisionResponse.Error).NotTo(HaveOccurred())
 		Expect(provisionResponse.StatusCode).To(Equal(http.StatusAccepted))
 
 		Eventually(func() bool {
-			lastOperationResponse := brokerClient.LastOperation(serviceInstanceGUID, requestID())
+			lastOperationResponse := testLab.Client().LastOperation(serviceInstanceGUID, requestID())
 			Expect(lastOperationResponse.Error).NotTo(HaveOccurred())
 			Expect(lastOperationResponse.StatusCode).To(Equal(http.StatusOK))
 			var receiver domain.LastOperation

--- a/internal/stableuuid/stable_uuid.go
+++ b/internal/stableuuid/stable_uuid.go
@@ -1,0 +1,16 @@
+package stableuuid
+
+import (
+	"crypto/sha256"
+
+	"github.com/google/uuid"
+	"golang.org/x/crypto/pbkdf2"
+)
+
+// FromStrings generates a UUID given two strings. For the same strings, the UUID
+// will always be the same.
+func FromStrings(s1, s2 string) string {
+	var data [16]byte
+	copy(data[:], pbkdf2.Key([]byte(s1), []byte(s2), 10, 16, sha256.New))
+	return uuid.Must(uuid.FromBytes(data[:])).String()
+}

--- a/internal/stableuuid/stableuuid_suite_test.go
+++ b/internal/stableuuid/stableuuid_suite_test.go
@@ -1,0 +1,13 @@
+package stableuuid_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestStableUUID(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "StableUUID Suite")
+}

--- a/internal/stableuuid/stableuuid_test.go
+++ b/internal/stableuuid/stableuuid_test.go
@@ -1,0 +1,32 @@
+package stableuuid_test
+
+import (
+	"github.com/cloudfoundry-incubator/cloud-service-broker/internal/stableuuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("StableUUID", func() {
+	It("generates the same UUID given the same strings", func() {
+		const s1 = "foo"
+		const s2 = "bar"
+		u1 := stableuuid.FromStrings(s1, s2)
+		u2 := stableuuid.FromStrings(s1, s2)
+		u3 := stableuuid.FromStrings(s1, s2)
+		Expect(u1).To(HaveLen(36))
+		Expect(u1).To(Equal(u2))
+		Expect(u1).To(Equal(u3))
+	})
+
+	It("generates a different UUID given different inputs strings", func() {
+		u1 := stableuuid.FromStrings("foo", "bar")
+		u2 := stableuuid.FromStrings("foo", "baz")
+		u3 := stableuuid.FromStrings("guz", "bar")
+		Expect(u1).To(HaveLen(36))
+		Expect(u2).To(HaveLen(36))
+		Expect(u3).To(HaveLen(36))
+		Expect(u1).NotTo(Equal(u2))
+		Expect(u1).NotTo(Equal(u3))
+		Expect(u2).NotTo(Equal(u3))
+	})
+})

--- a/pkg/broker/registry_test.go
+++ b/pkg/broker/registry_test.go
@@ -79,6 +79,28 @@ var _ = Describe("Registry", func() {
 				Expect(err).To(MatchError(`error validating service "test-service", duplicated value, must be unique: Builtin!: Plans[1].Name`))
 			})
 		})
+
+		Context("no plans defined", func() {
+			It("defines a default plan", func() {
+				registry := make(BrokerRegistry)
+
+				err := registry.Register(&ServiceDefinition{
+					Id:        "b9e4332e-b42b-4680-bda5-ea1506797474",
+					Name:      "test-service",
+					Plans:     []ServicePlan{},
+					IsBuiltin: true,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				services := registry.GetAllServices()
+				Expect(services).To(HaveLen(1))
+				plans := services[0].Plans
+				Expect(plans).To(HaveLen(1))
+				Expect(plans[0].ServicePlan.Name).To(Equal("default"))
+				Expect(plans[0].ServicePlan.Description).To(Equal("default plan"))
+				Expect(plans[0].ServicePlan.ID).To(HaveLen(36))
+			})
+		})
 	})
 
 	Describe("Validate", func() {


### PR DESCRIPTION
Previously if there were no brokerpak or user-defined plans then an
invalid catalog (with no plans) would be served. This change introduces
a default plan if none is defined. The plan ID is dervived from the
service name and service ID, so should be stable enough.

[#180992066](https://www.pivotaltracker.com/story/show/180992066)