### PR TITLE
fix: error when a service has no plans

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -4,4 +4,4 @@
 
 
 ### Fix:
-
+- When a service has no plans, there is now an error on broker startup.

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -57,6 +57,9 @@ func (brokerRegistry BrokerRegistry) Register(service *ServiceDefinition) error 
 		return fmt.Errorf("error getting user defined plans: %q, %s", name, err)
 	}
 	service.Plans = append(service.Plans, userPlans...)
+	if len(service.Plans) == 0 {
+		return fmt.Errorf("service %q has no plans defined; at least one plan must be specified in the service definition or via the environment variable %q or %q", service.Name, service.UserDefinedPlansVariable(), service.TileUserDefinedPlansVariable())
+	}
 
 	if err := service.Validate(); err != nil {
 		return fmt.Errorf("error validating service %q, %s", name, err)

--- a/pkg/broker/registry_test.go
+++ b/pkg/broker/registry_test.go
@@ -79,6 +79,20 @@ var _ = Describe("Registry", func() {
 				Expect(err).To(MatchError(`error validating service "test-service", duplicated value, must be unique: Builtin!: Plans[1].Name`))
 			})
 		})
+
+		Context("no plans defined", func() {
+			It("defines a default plan", func() {
+				registry := make(BrokerRegistry)
+
+				err := registry.Register(&ServiceDefinition{
+					Id:        "b9e4332e-b42b-4680-bda5-ea1506797474",
+					Name:      "test-service",
+					Plans:     []ServicePlan{},
+					IsBuiltin: true,
+				})
+				Expect(err).To(MatchError(`service "test-service" has no plans defined; at least one plan must be specified in the service definition or via the environment variable "GSB_SERVICE_TEST_SERVICE_PLANS" or "TEST_SERVICE_CUSTOM_PLANS"`))
+			})
+		})
 	})
 
 	Describe("Validate", func() {

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -131,6 +131,16 @@ func (svc *ServiceDefinition) UserDefinedPlansProperty() string {
 	return fmt.Sprintf("service.%s.plans", svc.Name)
 }
 
+func (svc *ServiceDefinition) UserDefinedPlansVariable() string {
+	return strings.ToUpper(
+		strings.ReplaceAll(
+			fmt.Sprintf("%s.service.%s.plans", utils.EnvironmentVarPrefix, utils.PropertyToEnvUnprefixed(svc.Name)),
+			".",
+			"_",
+		),
+	)
+}
+
 // ProvisionDefaultOverrideProperty returns the Viper property name for the
 // object users can set to override the default values on provision.
 func (svc *ServiceDefinition) ProvisionDefaultOverrideProperty() string {


### PR DESCRIPTION
If a service has no plans defined in the brokerpak or via environment
variables, then the "cf create-service-broker" command will fail.

This change makes the broker fail on startup if there are no plans, so
that a user gets faster feedback, and also some hints on how to resolve
the problem.

[#180992066](https://www.pivotaltracker.com/story/show/180992066)

### Checklist:

* [X] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

