### PR TITLE
fix: timeout when cannot connect to state database

### DIFF
--- a/db_service/setup_db.go
+++ b/db_service/setup_db.go
@@ -129,7 +129,7 @@ func setupMysqlDb(logger lager.Logger) (*gorm.DB, error) {
 		"name": dbName,
 	})
 
-	connStr := fmt.Sprintf("%v:%v@tcp(%v:%v)/%v?charset=utf8mb4&parseTime=True&loc=Local%v", dbUsername, dbPassword, dbHost, dbPort, dbName, tlsStr)
+	connStr := fmt.Sprintf("%v:%v@tcp(%v:%v)/%v?charset=utf8mb4&parseTime=True&loc=Local&timeout=30s%v", dbUsername, dbPassword, dbHost, dbPort, dbName, tlsStr)
 	return gorm.Open(gormmysql.New(gormmysql.Config{
 		DSN:               connStr,
 		DefaultStringSize: 256,

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -5,3 +5,4 @@
 
 ### Fix:
 - When a service has no plans, there is now an error on broker startup.
+- A 30s timeout has been added for connecting to the broker state database


### PR DESCRIPTION
Previously the DB connection timeout was not specified, which had the
effect of the app suspending if the database connection could not be
made without any useful error message.

### Checklist:

* [X] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

