### PR TITLE
fix: default Terraform version must be highest version

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -3,4 +3,5 @@
 ### Features:
 
 ### Fixes:
+- If multiple versions of Terraform are specified, the nominated default version must be highest version
 


### PR DESCRIPTION
When multiple versions of Terraform are specified, the version marked as
"default" must also be the highest version. Although only the default
version is currently used, it doesn't make sense to allow the default
version not to be the highest, as the purpose for specifying more than
one is to allow a future migration story.

[#181061009](https://www.pivotaltracker.com/story/show/181061009)

Co-authored-by: George Blue <gblue@pivotal.io>

### Checklist:

* [X] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

