### PR TITLE
chore: speedup pak command in tests

### DIFF
--- a/cmd/pak.go
+++ b/cmd/pak.go
@@ -19,11 +19,19 @@ import (
 	"log"
 	"os"
 
+	"github.com/spf13/viper"
+
 	"github.com/cloudfoundry/cloud-service-broker/pkg/brokerpak"
 	"github.com/spf13/cobra"
 )
 
+const (
+	pakCachePath = "pak.cache_path"
+)
+
 func init() {
+	viper.BindEnv(pakCachePath, "PAK_BUILD_CACHE_PATH")
+
 	pakCmd := &cobra.Command{
 		Use:   "pak",
 		Short: "interact with user-defined service definition bundles",
@@ -98,7 +106,7 @@ dependencies, services it provides, and the contents.
 				directory = args[0]
 			}
 
-			pakPath, err := brokerpak.Pack(directory)
+			pakPath, err := brokerpak.Pack(directory, viper.GetString(pakCachePath))
 			if err != nil {
 				log.Fatalf("error while packing %q: %v", directory, err)
 			}
@@ -171,7 +179,7 @@ dependencies, services it provides, and the contents.
 			}
 
 			// Edit the manifest to point to our local server
-			packname, err := brokerpak.Pack(td)
+			packname, err := brokerpak.Pack(td, "")
 			defer os.Remove(packname)
 			if err != nil {
 				log.Fatalf("couldn't pack brokerpak: %v", err)

--- a/internal/brokerpak/packer/cache.go
+++ b/internal/brokerpak/packer/cache.go
@@ -1,0 +1,56 @@
+package packer
+
+import (
+	"crypto/md5"
+	"fmt"
+	"log"
+	"os"
+	"path"
+
+	cp "github.com/otiai10/copy"
+)
+
+func copyFromCache(cachePath string, source string, destination string) bool {
+	if cachePath == "" {
+		return false
+	}
+	cacheKey := buildCacheKey(cachePath, source)
+	if _, err := os.Stat(cacheKey); err == nil {
+		cp.Copy(cacheKey, destination)
+		log.Println("\t", source, "found in cache at", cacheKey)
+		return true
+	} else {
+		return false
+	}
+}
+
+func populateCache(cachePath string, source string, destination string) {
+	if cachePath == "" {
+		return
+	}
+	cacheKey := buildCacheKey(cachePath, source)
+	err := cp.Copy(destination, cacheKey)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func buildCacheKey(cachePath string, source string) string {
+	return path.Join(cachePath, fmt.Sprintf("%x", md5.Sum([]byte(source))))
+}
+
+func cachedFetchFile(getter func(source string, destination string) error, source, destination, cachePath string) error {
+	if cachePath == "" {
+		return getter(source, destination)
+	}
+
+	if copyFromCache(cachePath, source, destination) {
+		return nil
+	}
+	err := getter(source, destination)
+	if err != nil {
+		return err
+	}
+	populateCache(cachePath, source, destination)
+	return nil
+}

--- a/internal/brokerpak/reader/reader_test.go
+++ b/internal/brokerpak/reader/reader_test.go
@@ -190,7 +190,7 @@ func fakeBrokerpak(opts ...option) string {
 	}
 
 	packName := path.Join(GinkgoT().TempDir(), "fake.brokerpak")
-	Expect(packer.Pack(m, dir, packName)).NotTo(HaveOccurred())
+	Expect(packer.Pack(m, dir, packName, "")).NotTo(HaveOccurred())
 	return packName
 }
 

--- a/pkg/brokerpak/cmd.go
+++ b/pkg/brokerpak/cmd.go
@@ -55,7 +55,7 @@ func Init(directory string) error {
 // Pack creates a new brokerpak from the given directory which MUST contain a
 // manifest.yml file. If the pack was successful, the returned string will be
 // the path to the created brokerpak.
-func Pack(directory string) (string, error) {
+func Pack(directory string, cachePath string) (string, error) {
 	data, err := os.ReadFile(filepath.Join(directory, manifestName))
 	if err != nil {
 		return "", err
@@ -72,7 +72,7 @@ func Pack(directory string) (string, error) {
 		version = m.Version
 	}
 	packname := fmt.Sprintf("%s-%s.brokerpak", m.Name, version)
-	return packname, packer.Pack(m, directory, packname)
+	return packname, packer.Pack(m, directory, packname, cachePath)
 }
 
 // Info writes out human-readable information about the brokerpak.

--- a/pkg/brokerpak/cmd_test.go
+++ b/pkg/brokerpak/cmd_test.go
@@ -94,7 +94,7 @@ func fakeBrokerpak() (string, error) {
 		}
 	}
 
-	return Pack(dir)
+	return Pack(dir, "")
 }
 
 func ExampleValidate() {


### PR DESCRIPTION
added caching which can be turned on by setting an enviornment variable on local
to speedup your local dev loops while running pak

[#181404983]

Signed-off-by: James Norman <normanja@vmware.com>

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

