### PR TITLE
chore: better error handling in storage layer

### DIFF
--- a/internal/storage/bind_request_details.go
+++ b/internal/storage/bind_request_details.go
@@ -60,7 +60,7 @@ func (s *Storage) GetBindRequestDetails(bindingID string, instanceID string) (js
 
 	decoded, err := s.decodeBytes(receiver.RequestDetails)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding bind request details: %w", err)
+		return nil, fmt.Errorf("error decoding bind request details %q: %w", bindingID, err)
 	}
 
 	return decoded, nil

--- a/internal/storage/bind_request_details_test.go
+++ b/internal/storage/bind_request_details_test.go
@@ -91,7 +91,7 @@ var _ = Describe("BindRequestDetails", func() {
 				encryptor.DecryptReturns(nil, errors.New("bang"))
 
 				_, err := store.GetBindRequestDetails("fake-binding-id", "fake-instance-id")
-				Expect(err).To(MatchError("error decoding bind request details: decryption error: bang"))
+				Expect(err).To(MatchError(`error decoding bind request details "fake-binding-id": decryption error: bang`))
 			})
 		})
 

--- a/internal/storage/encode.go
+++ b/internal/storage/encode.go
@@ -34,8 +34,11 @@ func (s *Storage) decodeBytes(a []byte) ([]byte, error) {
 
 func (s *Storage) decodeJSONObject(a []byte) (map[string]interface{}, error) {
 	b, err := s.decodeBytes(a)
-	if err != nil {
+	switch {
+	case err != nil:
 		return nil, err
+	case len(b) == 0:
+		return nil, nil
 	}
 
 	var receiver map[string]interface{}

--- a/internal/storage/provision_request_details.go
+++ b/internal/storage/provision_request_details.go
@@ -57,7 +57,7 @@ func (s *Storage) GetProvisionRequestDetails(serviceInstanceID string) (json.Raw
 
 	decoded, err := s.decodeBytes(receiver.RequestDetails)
 	if err != nil {
-		return nil, fmt.Errorf("error decoding provision request details: %w", err)
+		return nil, fmt.Errorf("error decoding provision request details %q: %w", serviceInstanceID, err)
 	}
 
 	return decoded, nil

--- a/internal/storage/provision_request_details_test.go
+++ b/internal/storage/provision_request_details_test.go
@@ -67,7 +67,7 @@ var _ = Describe("ProvisionRequestDetails", func() {
 				encryptor.DecryptReturns(nil, errors.New("bang"))
 
 				_, err := store.GetProvisionRequestDetails("fake-instance-id")
-				Expect(err).To(MatchError("error decoding provision request details: decryption error: bang"))
+				Expect(err).To(MatchError(`error decoding provision request details "fake-instance-id": decryption error: bang`))
 			})
 		})
 

--- a/internal/storage/service_binding_credentials.go
+++ b/internal/storage/service_binding_credentials.go
@@ -51,7 +51,7 @@ func (s *Storage) GetServiceBindingCredentials(bindingID, serviceInstanceID stri
 
 	decoded, err := s.decodeJSONObject(receiver.OtherDetails)
 	if err != nil {
-		return ServiceBindingCredentials{}, fmt.Errorf("error decoding credentials: %w", err)
+		return ServiceBindingCredentials{}, fmt.Errorf("error decoding binding credentials %q: %w", bindingID, err)
 	}
 
 	return ServiceBindingCredentials{

--- a/internal/storage/service_binding_credentials_test.go
+++ b/internal/storage/service_binding_credentials_test.go
@@ -70,7 +70,7 @@ var _ = Describe("ServiceBindingCredentials", func() {
 				encryptor.DecryptReturns(nil, errors.New("bang"))
 
 				_, err := store.GetServiceBindingCredentials("fake-binding-id", "fake-instance-id")
-				Expect(err).To(MatchError("error decoding credentials: decryption error: bang"))
+				Expect(err).To(MatchError(`error decoding binding credentials "fake-binding-id": decryption error: bang`))
 			})
 		})
 
@@ -78,6 +78,17 @@ var _ = Describe("ServiceBindingCredentials", func() {
 			It("returns an error", func() {
 				_, err := store.GetServiceBindingCredentials("not-there", "also-not-there")
 				Expect(err).To(MatchError(`could not find binding credentials for binding "not-there" and service instance "also-not-there"`))
+			})
+		})
+
+		When("OtherDetails field is empty", func() {
+			It("succeeds with an empty result", func() {
+				encryptor.DecryptReturns([]byte(""), nil)
+
+				r, err := store.GetServiceBindingCredentials("fake-binding-id", "fake-instance-id")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(r.Credentials).To(BeEmpty())
 			})
 		})
 	})

--- a/internal/storage/service_instance_details.go
+++ b/internal/storage/service_instance_details.go
@@ -83,7 +83,7 @@ func (s *Storage) GetServiceInstanceDetails(guid string) (ServiceInstanceDetails
 
 	decoded, err := s.decodeJSONObject(receiver.OtherDetails)
 	if err != nil {
-		return ServiceInstanceDetails{}, fmt.Errorf("error decoding outputs: %w", err)
+		return ServiceInstanceDetails{}, fmt.Errorf("error decoding service instance outputs %q: %w", guid, err)
 	}
 
 	return ServiceInstanceDetails{

--- a/internal/storage/service_instance_details_test.go
+++ b/internal/storage/service_instance_details_test.go
@@ -116,7 +116,7 @@ var _ = Describe("ServiceInstanceDetails", func() {
 				encryptor.DecryptReturns(nil, errors.New("bang"))
 
 				_, err := store.GetServiceInstanceDetails("fake-id-1")
-				Expect(err).To(MatchError("error decoding outputs: decryption error: bang"))
+				Expect(err).To(MatchError(`error decoding service instance outputs "fake-id-1": decryption error: bang`))
 			})
 		})
 
@@ -124,6 +124,17 @@ var _ = Describe("ServiceInstanceDetails", func() {
 			It("returns an error", func() {
 				_, err := store.GetServiceInstanceDetails("not-there")
 				Expect(err).To(MatchError("could not find service instance details for: not-there"))
+			})
+		})
+
+		When("OtherDetails field is empty", func() {
+			It("succeeds with an empty result", func() {
+				encryptor.DecryptReturns([]byte(""), nil)
+
+				r, err := store.GetServiceInstanceDetails("fake-id-1")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(r.Outputs).To(BeEmpty())
 			})
 		})
 	})

--- a/internal/storage/terraform_deployment.go
+++ b/internal/storage/terraform_deployment.go
@@ -61,7 +61,7 @@ func (s *Storage) GetTerraformDeployment(id string) (TerraformDeployment, error)
 
 	decoded, err := s.decodeBytes(receiver.Workspace)
 	if err != nil {
-		return TerraformDeployment{}, fmt.Errorf("error decoding workspace: %w", err)
+		return TerraformDeployment{}, fmt.Errorf("error decoding workspace %q: %w", id, err)
 	}
 
 	return TerraformDeployment{

--- a/internal/storage/terraform_deployments_test.go
+++ b/internal/storage/terraform_deployments_test.go
@@ -87,7 +87,7 @@ var _ = Describe("TerraformDeployments", func() {
 				encryptor.DecryptReturns(nil, errors.New("bang"))
 
 				_, err := store.GetTerraformDeployment("fake-id-1")
-				Expect(err).To(MatchError("error decoding workspace: decryption error: bang"))
+				Expect(err).To(MatchError(`error decoding workspace "fake-id-1": decryption error: bang`))
 			})
 		})
 


### PR DESCRIPTION
- now logs the object ID when decoding fails
- when parsing empty string as JSON, returns empty object rather than
failing

[#181481018](https://www.pivotaltracker.com/story/show/181481018)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

