### PR TITLE
chore: don't parse JSON when encrypting

### DIFF
--- a/internal/storage/update_all_records.go
+++ b/internal/storage/update_all_records.go
@@ -28,12 +28,12 @@ func (s *Storage) updateAllServiceBindingCredentials() error {
 	var serviceBindingCredentialsBatch []models.ServiceBindingCredentials
 	result := s.db.FindInBatches(&serviceBindingCredentialsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
 		for i := range serviceBindingCredentialsBatch {
-			creds, err := s.decodeJSONObject(serviceBindingCredentialsBatch[i].OtherDetails)
+			data, err := s.decodeBytes(serviceBindingCredentialsBatch[i].OtherDetails)
 			if err != nil {
 				return fmt.Errorf("decode error for %q: %w", serviceBindingCredentialsBatch[i].BindingId, err)
 			}
 
-			serviceBindingCredentialsBatch[i].OtherDetails, err = s.encodeJSON(creds)
+			serviceBindingCredentialsBatch[i].OtherDetails, err = s.encodeBytes(data)
 			if err != nil {
 				return fmt.Errorf("encode error for %q: %w", serviceBindingCredentialsBatch[i].BindingId, err)
 			}
@@ -52,12 +52,12 @@ func (s *Storage) updateAllBindRequestDetails() error {
 	var bindRequestDetailsBatch []models.BindRequestDetails
 	result := s.db.FindInBatches(&bindRequestDetailsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
 		for i := range bindRequestDetailsBatch {
-			details, err := s.decodeBytes(bindRequestDetailsBatch[i].RequestDetails)
+			data, err := s.decodeBytes(bindRequestDetailsBatch[i].RequestDetails)
 			if err != nil {
 				return fmt.Errorf("decode error for %q: %w", bindRequestDetailsBatch[i].ServiceBindingId, err)
 			}
 
-			bindRequestDetailsBatch[i].RequestDetails, err = s.encodeBytes(details)
+			bindRequestDetailsBatch[i].RequestDetails, err = s.encodeBytes(data)
 			if err != nil {
 				return fmt.Errorf("encode error for %q: %w", bindRequestDetailsBatch[i].ServiceBindingId, err)
 			}
@@ -76,12 +76,12 @@ func (s *Storage) updateAllProvisionRequestDetails() error {
 	var provisionRequestDetailsBatch []models.ProvisionRequestDetails
 	result := s.db.FindInBatches(&provisionRequestDetailsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
 		for i := range provisionRequestDetailsBatch {
-			details, err := s.decodeBytes(provisionRequestDetailsBatch[i].RequestDetails)
+			data, err := s.decodeBytes(provisionRequestDetailsBatch[i].RequestDetails)
 			if err != nil {
 				return fmt.Errorf("decode error for %q: %w", provisionRequestDetailsBatch[i].ServiceInstanceId, err)
 			}
 
-			provisionRequestDetailsBatch[i].RequestDetails, err = s.encodeBytes(details)
+			provisionRequestDetailsBatch[i].RequestDetails, err = s.encodeBytes(data)
 			if err != nil {
 				return fmt.Errorf("encode error for %q: %w", provisionRequestDetailsBatch[i].ServiceInstanceId, err)
 			}
@@ -100,12 +100,12 @@ func (s *Storage) updateAllServiceInstanceDetails() error {
 	var serviceInstanceDetailsBatch []models.ServiceInstanceDetails
 	result := s.db.FindInBatches(&serviceInstanceDetailsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
 		for i := range serviceInstanceDetailsBatch {
-			outputs, err := s.decodeJSONObject(serviceInstanceDetailsBatch[i].OtherDetails)
+			data, err := s.decodeBytes(serviceInstanceDetailsBatch[i].OtherDetails)
 			if err != nil {
 				return fmt.Errorf("decode error for %q: %w", serviceInstanceDetailsBatch[i].ID, err)
 			}
 
-			serviceInstanceDetailsBatch[i].OtherDetails, err = s.encodeJSON(outputs)
+			serviceInstanceDetailsBatch[i].OtherDetails, err = s.encodeBytes(data)
 			if err != nil {
 				return fmt.Errorf("encode error for %q: %w", serviceInstanceDetailsBatch[i].ID, err)
 			}
@@ -124,12 +124,12 @@ func (s *Storage) updateAllTerraformDeployments() error {
 	var terraformDeploymentBatch []models.TerraformDeployment
 	result := s.db.FindInBatches(&terraformDeploymentBatch, 100, func(tx *gorm.DB, batchNumber int) error {
 		for i := range terraformDeploymentBatch {
-			workspace, err := s.decodeBytes(terraformDeploymentBatch[i].Workspace)
+			data, err := s.decodeBytes(terraformDeploymentBatch[i].Workspace)
 			if err != nil {
 				return fmt.Errorf("decode error for %q: %w", terraformDeploymentBatch[i].ID, err)
 			}
 
-			terraformDeploymentBatch[i].Workspace, err = s.encodeBytes(workspace)
+			terraformDeploymentBatch[i].Workspace, err = s.encodeBytes(data)
 			if err != nil {
 				return fmt.Errorf("encode error for %q: %w", terraformDeploymentBatch[i].ID, err)
 			}

--- a/internal/storage/update_all_records_test.go
+++ b/internal/storage/update_all_records_test.go
@@ -67,21 +67,6 @@ var _ = Describe("UpdateAllRecords", func() {
 
 	Describe("errors", func() {
 		Context("service binding credentials", func() {
-			When("OtherDetails is not JSON", func() {
-				BeforeEach(func() {
-					Expect(db.Create(&models.ServiceBindingCredentials{
-						OtherDetails:      []byte(`not-json`),
-						ServiceId:         "fake-other-service-id",
-						ServiceInstanceId: "fake-instance-id",
-						BindingId:         "fake-bad-binding-id",
-					}).Error).NotTo(HaveOccurred())
-				})
-
-				It("returns an error", func() {
-					Expect(store.UpdateAllRecords()).To(MatchError(`error re-encoding service binding credentials: decode error for "fake-bad-binding-id": JSON parse error: invalid character 'o' in literal null (expecting 'u')`))
-				})
-			})
-
 			When("OtherDetails cannot be decrypted", func() {
 				BeforeEach(func() {
 					Expect(db.Create(&models.ServiceBindingCredentials{
@@ -172,19 +157,6 @@ var _ = Describe("UpdateAllRecords", func() {
 		})
 
 		Context("service instance details", func() {
-			When("OtherDetails is not JSON", func() {
-				BeforeEach(func() {
-					Expect(db.Create(&models.ServiceInstanceDetails{
-						ID:           "fake-bad-id",
-						OtherDetails: []byte(`not-json`),
-					}).Error).NotTo(HaveOccurred())
-				})
-
-				It("returns an error", func() {
-					Expect(store.UpdateAllRecords()).To(MatchError(`error re-encoding service instance details: decode error for "fake-bad-id": JSON parse error: invalid character 'o' in literal null (expecting 'u')`))
-				})
-			})
-
 			When("OtherDetails cannot be decrypted", func() {
 				BeforeEach(func() {
 					Expect(db.Create(&models.ServiceInstanceDetails{


### PR DESCRIPTION
When encrypting the database, we currently parse and then marshal certain JSON fields.
This is not a required step as we can just decrtypt the previous data as
bytes and then re-encrypt.

[#181481018](https://www.pivotaltracker.com/story/show/181481018)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

