### PR TITLE
fix: check readability of database before encryption actions

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -8,4 +8,5 @@
 - Fixed missing insert in message when building brokerpak from current working directory
 - Error messages during encryption tell you how to fix the issue
 - Error messages during encryption log DB row ID
+- Checks the database for readability of all fields before attempting encryption or removing salt
 

--- a/internal/storage/check_all_records.go
+++ b/internal/storage/check_all_records.go
@@ -1,0 +1,124 @@
+package storage
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+
+	"github.com/cloudfoundry/cloud-service-broker/db_service/models"
+	"gorm.io/gorm"
+)
+
+func (s *Storage) CheckAllRecords() error {
+	var errs *multierror.Error
+
+	checkers := []func() *multierror.Error{
+		s.checkAllServiceBindingCredentials,
+		s.checkAllBindRequestDetails,
+		s.checkAllProvisionRequestDetails,
+		s.checkAllServiceInstanceDetails,
+		s.checkAllTerraformDeployments,
+	}
+	for _, e := range checkers {
+		if err := e(); err != nil {
+			errs = multierror.Append(err, errs)
+		}
+	}
+
+	return errs.ErrorOrNil()
+}
+
+func (s *Storage) checkAllServiceBindingCredentials() (errs *multierror.Error) {
+	var serviceBindingCredentialsBatch []models.ServiceBindingCredentials
+	result := s.db.FindInBatches(&serviceBindingCredentialsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
+		for i := range serviceBindingCredentialsBatch {
+			_, err := s.decodeJSONObject(serviceBindingCredentialsBatch[i].OtherDetails)
+			if err != nil {
+				errs = multierror.Append(fmt.Errorf("decode error for service binding credential %q: %w", serviceBindingCredentialsBatch[i].BindingId, err), errs)
+			}
+		}
+
+		return nil
+	})
+	if result.Error != nil {
+		errs = multierror.Append(fmt.Errorf("error reading service binding credentials: %w", result.Error), errs)
+	}
+
+	return errs
+}
+
+func (s *Storage) checkAllBindRequestDetails() (errs *multierror.Error) {
+	var bindRequestDetailsBatch []models.BindRequestDetails
+	result := s.db.FindInBatches(&bindRequestDetailsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
+		for i := range bindRequestDetailsBatch {
+			_, err := s.decodeBytes(bindRequestDetailsBatch[i].RequestDetails)
+			if err != nil {
+				errs = multierror.Append(fmt.Errorf("decode error for binding request details %q: %w", bindRequestDetailsBatch[i].ServiceBindingId, err), errs)
+			}
+		}
+
+		return nil
+	})
+	if result.Error != nil {
+		errs = multierror.Append(fmt.Errorf("error reading binding request details: %w", result.Error), errs)
+	}
+
+	return errs
+}
+
+func (s *Storage) checkAllProvisionRequestDetails() (errs *multierror.Error) {
+	var provisionRequestDetailsBatch []models.ProvisionRequestDetails
+	result := s.db.FindInBatches(&provisionRequestDetailsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
+		for i := range provisionRequestDetailsBatch {
+			_, err := s.decodeBytes(provisionRequestDetailsBatch[i].RequestDetails)
+			if err != nil {
+				errs = multierror.Append(fmt.Errorf("decode error for provision request details %q: %w", provisionRequestDetailsBatch[i].ServiceInstanceId, err), errs)
+			}
+		}
+
+		return nil
+	})
+	if result.Error != nil {
+		errs = multierror.Append(fmt.Errorf("error reading provision request details: %w", result.Error), errs)
+	}
+
+	return errs
+}
+
+func (s *Storage) checkAllServiceInstanceDetails() (errs *multierror.Error) {
+	var serviceInstanceDetailsBatch []models.ServiceInstanceDetails
+	result := s.db.FindInBatches(&serviceInstanceDetailsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
+		for i := range serviceInstanceDetailsBatch {
+			_, err := s.decodeJSONObject(serviceInstanceDetailsBatch[i].OtherDetails)
+			if err != nil {
+				errs = multierror.Append(fmt.Errorf("decode error for service instance details %q: %w", serviceInstanceDetailsBatch[i].ID, err), errs)
+			}
+		}
+
+		return nil
+	})
+	if result.Error != nil {
+		errs = multierror.Append(fmt.Errorf("error re-encoding service instance details: %w", result.Error), errs)
+	}
+
+	return errs
+}
+
+func (s *Storage) checkAllTerraformDeployments() (errs *multierror.Error) {
+	var terraformDeploymentBatch []models.TerraformDeployment
+	result := s.db.FindInBatches(&terraformDeploymentBatch, 100, func(tx *gorm.DB, batchNumber int) error {
+		for i := range terraformDeploymentBatch {
+			_, err := s.decodeBytes(terraformDeploymentBatch[i].Workspace)
+			if err != nil {
+				errs = multierror.Append(fmt.Errorf("decode error for terraform deployment %q: %w", terraformDeploymentBatch[i].ID, err), errs)
+			}
+		}
+
+		return nil
+	})
+	if result.Error != nil {
+		errs = multierror.Append(fmt.Errorf("error re-encoding terraform deployment: %w", result.Error), errs)
+	}
+
+	return errs
+}

--- a/internal/storage/check_all_records_test.go
+++ b/internal/storage/check_all_records_test.go
@@ -1,0 +1,83 @@
+package storage_test
+
+import (
+	"github.com/cloudfoundry/cloud-service-broker/db_service/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CheckAllRecords", func() {
+
+	BeforeEach(func() {
+		//encryptor = &storagefakes.FakeEncryptor{}
+
+		addFakeServiceCredentialBindings()
+		addFakeProvisionRequestDetails()
+		addFakeBindRequestDetails()
+		addFakeServiceInstanceDetails()
+		addFakeTerraformDeployments()
+	})
+
+	It("does not fail", func() {
+		Expect(store.CheckAllRecords()).NotTo(HaveOccurred())
+	})
+
+	When("the database contains invalid data", func() {
+		BeforeEach(func() {
+			Expect(db.Create(&models.ServiceBindingCredentials{
+				OtherDetails:      []byte(`binding-not-json-2`),
+				ServiceId:         "fake-other-service-id",
+				ServiceInstanceId: "fake-bad-instance-id",
+				BindingId:         "fake-bad-binding-id-1",
+			}).Error).NotTo(HaveOccurred())
+
+			Expect(db.Create(&models.ServiceBindingCredentials{
+				OtherDetails:      []byte(`cannot-be-decrypted`),
+				ServiceId:         "fake-other-service-id",
+				ServiceInstanceId: "fake-bad-instance-id",
+				BindingId:         "fake-bad-binding-id-2",
+			}).Error).NotTo(HaveOccurred())
+
+			Expect(db.Create(&models.ProvisionRequestDetails{
+				RequestDetails:    []byte(`cannot-be-decrypted`),
+				ServiceInstanceId: "fake-bad-instance-id",
+			}).Error).NotTo(HaveOccurred())
+
+			Expect(db.Create(&models.BindRequestDetails{
+				RequestDetails:    []byte(`cannot-be-decrypted`),
+				ServiceBindingId:  "fake-bad-binding-id",
+				ServiceInstanceId: "fake-bad-instance-id",
+			}).Error).NotTo(HaveOccurred())
+
+			Expect(db.Create(&models.ServiceInstanceDetails{
+				ID:           "fake-bad-instance-id-1",
+				OtherDetails: []byte(`service-instance-not-json`),
+			}).Error).NotTo(HaveOccurred())
+
+			Expect(db.Create(&models.ServiceInstanceDetails{
+				ID:           "fake-bad-instance-id-2",
+				OtherDetails: []byte(`cannot-be-decrypted`),
+			}).Error).NotTo(HaveOccurred())
+
+			Expect(db.Create(&models.TerraformDeployment{
+				ID:                   "fake-bad-id",
+				Workspace:            []byte("cannot-be-decrypted"),
+				LastOperationType:    "create",
+				LastOperationState:   "succeeded",
+				LastOperationMessage: "amazing",
+			}).Error).NotTo(HaveOccurred())
+		})
+
+		It("returns all errors", func() {
+			Expect(store.CheckAllRecords()).To(MatchError(And(
+				ContainSubstring(`decode error for service binding credential "fake-bad-binding-id-1": JSON parse error: invalid character 'b' looking for beginning of value`),
+				ContainSubstring(`decode error for service binding credential "fake-bad-binding-id-2": decryption error: fake decryption error`),
+				ContainSubstring(`decode error for provision request details "fake-bad-instance-id": decryption error: fake decryption error`),
+				ContainSubstring(`decode error for binding request details "fake-bad-binding-id": decryption error: fake decryption error`),
+				ContainSubstring(`decode error for service instance details "fake-bad-instance-id-1": JSON parse error: invalid character 's' looking for beginning of value`),
+				ContainSubstring(`decode error for service instance details "fake-bad-instance-id-2": decryption error: fake decryption error`),
+				ContainSubstring(`decode error for terraform deployment "fake-bad-id": decryption error: fake decryption error`),
+			)))
+		})
+	})
+})

--- a/internal/storage/update_all_records.go
+++ b/internal/storage/update_all_records.go
@@ -42,7 +42,7 @@ func (s *Storage) updateAllServiceBindingCredentials() error {
 		return tx.Save(&serviceBindingCredentialsBatch).Error
 	})
 	if result.Error != nil {
-		return fmt.Errorf("error re-encoding service binding credentials: %v", result.Error)
+		return fmt.Errorf("error re-encoding service binding credentials: %w", result.Error)
 	}
 
 	return nil
@@ -66,7 +66,7 @@ func (s *Storage) updateAllBindRequestDetails() error {
 		return tx.Save(&bindRequestDetailsBatch).Error
 	})
 	if result.Error != nil {
-		return fmt.Errorf("error re-encoding service binding request details: %v", result.Error)
+		return fmt.Errorf("error re-encoding service binding request details: %w", result.Error)
 	}
 
 	return nil
@@ -90,7 +90,7 @@ func (s *Storage) updateAllProvisionRequestDetails() error {
 		return tx.Save(&provisionRequestDetailsBatch).Error
 	})
 	if result.Error != nil {
-		return fmt.Errorf("error re-encoding provision request details: %v", result.Error)
+		return fmt.Errorf("error re-encoding provision request details: %w", result.Error)
 	}
 
 	return nil
@@ -114,7 +114,7 @@ func (s *Storage) updateAllServiceInstanceDetails() error {
 		return tx.Save(&serviceInstanceDetailsBatch).Error
 	})
 	if result.Error != nil {
-		return fmt.Errorf("error re-encoding service instance details: %v", result.Error)
+		return fmt.Errorf("error re-encoding service instance details: %w", result.Error)
 	}
 
 	return nil
@@ -138,7 +138,7 @@ func (s *Storage) updateAllTerraformDeployments() error {
 		return tx.Save(&terraformDeploymentBatch).Error
 	})
 	if result.Error != nil {
-		return fmt.Errorf("error re-encoding terraform deployment: %v", result.Error)
+		return fmt.Errorf("error re-encoding terraform deployment: %w", result.Error)
 	}
 
 	return nil


### PR DESCRIPTION
If there is a problem with reading any field in the database, then we
should fail fast before attempting to encrypt the database, so that we
reduce the change of the database ending up in a partially encrypted
state.

If there is a problem with reading any field in the database, then we
should not attempt to remove any password metadata as it's possible that
the reason the database cannot be read is due to a password having been
removed, and we want to keep the value of any salt so that an encryption
key can still be make.

These checks do access every row in the database. We believe that
databases are small (1000 rows or fewer per table) so this should be
fast, but we would need to revisit if we discovered a customer who is
running at a large enough scale for this to cause performance issues.

[#181522793](https://www.pivotaltracker.com/story/show/181522793)

### Checklist:

* [X] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

