### PR TITLE
chore: parse provision request details in storage layer

### DIFF
--- a/brokerapi/broker/broker.go
+++ b/brokerapi/broker/broker.go
@@ -15,7 +15,6 @@
 package broker
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -55,14 +54,9 @@ func New(cfg *BrokerConfig, logger lager.Logger, store Storage) (*ServiceBroker,
 	}, nil
 }
 
-func validateProvisionParameters(rawParams json.RawMessage, validUserInputFields []broker.BrokerVariable, validImportFields []broker.ImportVariable, plan *broker.ServicePlan) error {
-	if len(rawParams) == 0 {
+func validateProvisionParameters(params map[string]interface{}, validUserInputFields []broker.BrokerVariable, validImportFields []broker.ImportVariable, plan *broker.ServicePlan) error {
+	if len(params) == 0 {
 		return nil
-	}
-
-	var params map[string]interface{}
-	if err := json.Unmarshal(rawParams, &params); err != nil {
-		return ErrInvalidUserInput
 	}
 
 	// As this is a new check we have feature-flagged it so that it can easily be disabled

--- a/brokerapi/broker/broker_test.go
+++ b/brokerapi/broker/broker_test.go
@@ -192,7 +192,7 @@ func fakeService(t *testing.T, isAsync bool) *serviceStub {
 			BindStub: func(ctx context.Context, vc *varcontext.VarContext) (map[string]interface{}, error) {
 				return map[string]interface{}{"foo": "bar"}, nil
 			},
-			BuildInstanceCredentialsStub: func(ctx context.Context, creds map[string]interface{}, outs storage.TerraformOutputs) (*domain.Binding, error) {
+			BuildInstanceCredentialsStub: func(ctx context.Context, creds map[string]interface{}, outs storage.JSONObject) (*domain.Binding, error) {
 				mixin := base.MergedInstanceCredsMixin{}
 				return mixin.BuildInstanceCredentials(ctx, creds, outs)
 			},

--- a/brokerapi/broker/brokerfakes/fake_storage.go
+++ b/brokerapi/broker/brokerfakes/fake_storage.go
@@ -121,17 +121,17 @@ type FakeStorage struct {
 		result1 json.RawMessage
 		result2 error
 	}
-	GetProvisionRequestDetailsStub        func(string) (json.RawMessage, error)
+	GetProvisionRequestDetailsStub        func(string) (storage.JSONObject, error)
 	getProvisionRequestDetailsMutex       sync.RWMutex
 	getProvisionRequestDetailsArgsForCall []struct {
 		arg1 string
 	}
 	getProvisionRequestDetailsReturns struct {
-		result1 json.RawMessage
+		result1 storage.JSONObject
 		result2 error
 	}
 	getProvisionRequestDetailsReturnsOnCall map[int]struct {
-		result1 json.RawMessage
+		result1 storage.JSONObject
 		result2 error
 	}
 	GetServiceBindingCredentialsStub        func(string, string) (storage.ServiceBindingCredentials, error)
@@ -185,11 +185,11 @@ type FakeStorage struct {
 	storeBindRequestDetailsReturnsOnCall map[int]struct {
 		result1 error
 	}
-	StoreProvisionRequestDetailsStub        func(string, json.RawMessage) error
+	StoreProvisionRequestDetailsStub        func(string, storage.JSONObject) error
 	storeProvisionRequestDetailsMutex       sync.RWMutex
 	storeProvisionRequestDetailsArgsForCall []struct {
 		arg1 string
-		arg2 json.RawMessage
+		arg2 storage.JSONObject
 	}
 	storeProvisionRequestDetailsReturns struct {
 		result1 error
@@ -788,7 +788,7 @@ func (fake *FakeStorage) GetBindRequestDetailsReturnsOnCall(i int, result1 json.
 	}{result1, result2}
 }
 
-func (fake *FakeStorage) GetProvisionRequestDetails(arg1 string) (json.RawMessage, error) {
+func (fake *FakeStorage) GetProvisionRequestDetails(arg1 string) (storage.JSONObject, error) {
 	fake.getProvisionRequestDetailsMutex.Lock()
 	ret, specificReturn := fake.getProvisionRequestDetailsReturnsOnCall[len(fake.getProvisionRequestDetailsArgsForCall)]
 	fake.getProvisionRequestDetailsArgsForCall = append(fake.getProvisionRequestDetailsArgsForCall, struct {
@@ -813,7 +813,7 @@ func (fake *FakeStorage) GetProvisionRequestDetailsCallCount() int {
 	return len(fake.getProvisionRequestDetailsArgsForCall)
 }
 
-func (fake *FakeStorage) GetProvisionRequestDetailsCalls(stub func(string) (json.RawMessage, error)) {
+func (fake *FakeStorage) GetProvisionRequestDetailsCalls(stub func(string) (storage.JSONObject, error)) {
 	fake.getProvisionRequestDetailsMutex.Lock()
 	defer fake.getProvisionRequestDetailsMutex.Unlock()
 	fake.GetProvisionRequestDetailsStub = stub
@@ -826,28 +826,28 @@ func (fake *FakeStorage) GetProvisionRequestDetailsArgsForCall(i int) string {
 	return argsForCall.arg1
 }
 
-func (fake *FakeStorage) GetProvisionRequestDetailsReturns(result1 json.RawMessage, result2 error) {
+func (fake *FakeStorage) GetProvisionRequestDetailsReturns(result1 storage.JSONObject, result2 error) {
 	fake.getProvisionRequestDetailsMutex.Lock()
 	defer fake.getProvisionRequestDetailsMutex.Unlock()
 	fake.GetProvisionRequestDetailsStub = nil
 	fake.getProvisionRequestDetailsReturns = struct {
-		result1 json.RawMessage
+		result1 storage.JSONObject
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeStorage) GetProvisionRequestDetailsReturnsOnCall(i int, result1 json.RawMessage, result2 error) {
+func (fake *FakeStorage) GetProvisionRequestDetailsReturnsOnCall(i int, result1 storage.JSONObject, result2 error) {
 	fake.getProvisionRequestDetailsMutex.Lock()
 	defer fake.getProvisionRequestDetailsMutex.Unlock()
 	fake.GetProvisionRequestDetailsStub = nil
 	if fake.getProvisionRequestDetailsReturnsOnCall == nil {
 		fake.getProvisionRequestDetailsReturnsOnCall = make(map[int]struct {
-			result1 json.RawMessage
+			result1 storage.JSONObject
 			result2 error
 		})
 	}
 	fake.getProvisionRequestDetailsReturnsOnCall[i] = struct {
-		result1 json.RawMessage
+		result1 storage.JSONObject
 		result2 error
 	}{result1, result2}
 }
@@ -1106,12 +1106,12 @@ func (fake *FakeStorage) StoreBindRequestDetailsReturnsOnCall(i int, result1 err
 	}{result1}
 }
 
-func (fake *FakeStorage) StoreProvisionRequestDetails(arg1 string, arg2 json.RawMessage) error {
+func (fake *FakeStorage) StoreProvisionRequestDetails(arg1 string, arg2 storage.JSONObject) error {
 	fake.storeProvisionRequestDetailsMutex.Lock()
 	ret, specificReturn := fake.storeProvisionRequestDetailsReturnsOnCall[len(fake.storeProvisionRequestDetailsArgsForCall)]
 	fake.storeProvisionRequestDetailsArgsForCall = append(fake.storeProvisionRequestDetailsArgsForCall, struct {
 		arg1 string
-		arg2 json.RawMessage
+		arg2 storage.JSONObject
 	}{arg1, arg2})
 	stub := fake.StoreProvisionRequestDetailsStub
 	fakeReturns := fake.storeProvisionRequestDetailsReturns
@@ -1132,13 +1132,13 @@ func (fake *FakeStorage) StoreProvisionRequestDetailsCallCount() int {
 	return len(fake.storeProvisionRequestDetailsArgsForCall)
 }
 
-func (fake *FakeStorage) StoreProvisionRequestDetailsCalls(stub func(string, json.RawMessage) error) {
+func (fake *FakeStorage) StoreProvisionRequestDetailsCalls(stub func(string, storage.JSONObject) error) {
 	fake.storeProvisionRequestDetailsMutex.Lock()
 	defer fake.storeProvisionRequestDetailsMutex.Unlock()
 	fake.StoreProvisionRequestDetailsStub = stub
 }
 
-func (fake *FakeStorage) StoreProvisionRequestDetailsArgsForCall(i int) (string, json.RawMessage) {
+func (fake *FakeStorage) StoreProvisionRequestDetailsArgsForCall(i int) (string, storage.JSONObject) {
 	fake.storeProvisionRequestDetailsMutex.RLock()
 	defer fake.storeProvisionRequestDetailsMutex.RUnlock()
 	argsForCall := fake.storeProvisionRequestDetailsArgsForCall[i]

--- a/brokerapi/broker/deprovision.go
+++ b/brokerapi/broker/deprovision.go
@@ -6,6 +6,7 @@ import (
 
 	"code.cloudfoundry.org/lager"
 	"github.com/cloudfoundry/cloud-service-broker/db_service/models"
+	"github.com/cloudfoundry/cloud-service-broker/internal/paramparser"
 	"github.com/cloudfoundry/cloud-service-broker/utils/correlation"
 	"github.com/cloudfoundry/cloud-service-broker/utils/request"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
@@ -52,15 +53,15 @@ func (broker *ServiceBroker) Deprovision(ctx context.Context, instanceID string,
 		return response, apiresponses.ErrAsyncRequired
 	}
 
-	rawParameters, err := broker.store.GetProvisionRequestDetails(instanceID)
+	parameters, err := broker.store.GetProvisionRequestDetails(instanceID)
 	if err != nil {
 		return response, fmt.Errorf("error retrieving provision request details for %q: %w", instanceID, err)
 	}
 
-	provisionDetails := domain.ProvisionDetails{
+	provisionDetails := paramparser.ProvisionDetails{
 		ServiceID:     details.ServiceID,
 		PlanID:        details.PlanID,
-		RawParameters: rawParameters,
+		RequestParams: parameters,
 	}
 
 	// validate parameters meet the service's schema and merge the user vars with

--- a/brokerapi/broker/deprovision_test.go
+++ b/brokerapi/broker/deprovision_test.go
@@ -1,7 +1,6 @@
 package broker_test
 
 import (
-	"encoding/json"
 	"errors"
 
 	"github.com/cloudfoundry/cloud-service-broker/pkg/varcontext"
@@ -75,7 +74,7 @@ var _ = Describe("Deprovision", func() {
 
 		fakeStorage = &brokerfakes.FakeStorage{}
 		fakeStorage.ExistsServiceInstanceDetailsReturns(true, nil)
-		fakeStorage.GetProvisionRequestDetailsReturns(json.RawMessage{}, nil)
+		fakeStorage.GetProvisionRequestDetailsReturns(nil, nil)
 		fakeStorage.GetServiceInstanceDetailsReturns(storage.ServiceInstanceDetails{
 			ServiceGUID:      offeringID,
 			PlanGUID:         planID,
@@ -133,7 +132,7 @@ var _ = Describe("Deprovision", func() {
 		Describe("deprovision variables", func() {
 			When("there were provision variables during provision or update", func() {
 				BeforeEach(func() {
-					fakeStorage.GetProvisionRequestDetailsReturns(json.RawMessage(`{"foo":"something", "import_field_1":"hello"}`), nil)
+					fakeStorage.GetProvisionRequestDetailsReturns(map[string]interface{}{"foo": "something", "import_field_1": "hello"}, nil)
 				})
 
 				It("should use the provision variables", func() {
@@ -286,7 +285,7 @@ var _ = Describe("Deprovision", func() {
 
 		When("storage errors when getting provision params", func() {
 			BeforeEach(func() {
-				fakeStorage.GetProvisionRequestDetailsReturns(json.RawMessage{}, errors.New("failed to get SI provision params"))
+				fakeStorage.GetProvisionRequestDetailsReturns(nil, errors.New("failed to get SI provision params"))
 			})
 
 			It("should error", func() {

--- a/brokerapi/broker/last_instance_operation_test.go
+++ b/brokerapi/broker/last_instance_operation_test.go
@@ -35,14 +35,14 @@ var _ = Describe("LastInstanceOperation", func() {
 
 		fakeStorage         *brokerfakes.FakeStorage
 		fakeServiceProvider *pkgBrokerFakes.FakeServiceProvider
-		expectedTFOutput    storage.TerraformOutputs
+		expectedTFOutput    storage.JSONObject
 	)
 
 	BeforeEach(func() {
 		fakeServiceProvider = &pkgBrokerFakes.FakeServiceProvider{}
 		fakeServiceProvider.ProvisionsAsyncReturns(true)
 		fakeServiceProvider.DeprovisionsAsyncReturns(true)
-		expectedTFOutput = storage.TerraformOutputs{"output": "value"}
+		expectedTFOutput = storage.JSONObject{"output": "value"}
 		fakeServiceProvider.GetTerraformOutputsReturns(expectedTFOutput, nil)
 		fakeServiceProvider.PollInstanceReturns(true, "operation complete", nil)
 

--- a/brokerapi/broker/provision_test.go
+++ b/brokerapi/broker/provision_test.go
@@ -155,11 +155,11 @@ var _ = Describe("Provision", func() {
 		})
 
 		It("should provision with parameters", func() {
-			expectedParams := json.RawMessage(`{"foo":"something", "import_field_1":"hello"}`)
+			expectedParams := storage.JSONObject{"foo": "something", "import_field_1": "hello"}
 			provisionDetails = domain.ProvisionDetails{
 				ServiceID:     offeringID,
 				PlanID:        planID,
-				RawParameters: expectedParams,
+				RawParameters: json.RawMessage(`{"foo":"something", "import_field_1":"hello"}`),
 			}
 
 			_, err := serviceBroker.Provision(context.TODO(), newInstanceID, provisionDetails, true)

--- a/brokerapi/broker/storage.go
+++ b/brokerapi/broker/storage.go
@@ -21,8 +21,8 @@ type Storage interface {
 	StoreBindRequestDetails(bindRequestDetails storage.BindRequestDetails) error
 	GetBindRequestDetails(bindingID, instanceID string) (json.RawMessage, error)
 	DeleteBindRequestDetails(bindingID, instanceID string) error
-	StoreProvisionRequestDetails(serviceInstanceID string, details json.RawMessage) error
-	GetProvisionRequestDetails(serviceInstanceID string) (json.RawMessage, error)
+	StoreProvisionRequestDetails(serviceInstanceID string, details storage.JSONObject) error
+	GetProvisionRequestDetails(serviceInstanceID string) (storage.JSONObject, error)
 	DeleteProvisionRequestDetails(serviceInstanceID string) error
 	StoreServiceInstanceDetails(d storage.ServiceInstanceDetails) error
 	GetServiceInstanceDetails(guid string) (storage.ServiceInstanceDetails, error)

--- a/brokerapi/broker/update_test.go
+++ b/brokerapi/broker/update_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Update", func() {
 				Expect(fakeStorage.StoreProvisionRequestDetailsCallCount()).To(Equal(1))
 				actualSI, actualParams := fakeStorage.StoreProvisionRequestDetailsArgsForCall(0)
 				Expect(actualSI).To(Equal(instanceID))
-				Expect(actualParams).To(Equal(json.RawMessage(`{}`)))
+				Expect(actualParams).To(BeEmpty())
 			})
 		})
 
@@ -262,7 +262,7 @@ var _ = Describe("Update", func() {
 				By("validating provision details have been stored")
 				Expect(fakeStorage.StoreProvisionRequestDetailsCallCount()).To(Equal(1))
 				_, actualRequestVars := fakeStorage.StoreProvisionRequestDetailsArgsForCall(0)
-				Expect(actualRequestVars).To(Equal(json.RawMessage(`{"foo":"quz","guz":"muz"}`)))
+				Expect(actualRequestVars).To(Equal(storage.JSONObject{"foo": "quz", "guz": "muz"}))
 			})
 		})
 	})
@@ -270,7 +270,7 @@ var _ = Describe("Update", func() {
 	Describe("update variables", func() {
 		Describe("passing variables on provision and update", func() {
 			BeforeEach(func() {
-				fakeStorage.GetProvisionRequestDetailsReturns(json.RawMessage(`{"foo":"bar","baz":"quz"}`), nil)
+				fakeStorage.GetProvisionRequestDetailsReturns(map[string]interface{}{"foo": "bar", "baz": "quz"}, nil)
 			})
 
 			It("should merge all variables", func() {
@@ -303,13 +303,13 @@ var _ = Describe("Update", func() {
 				By("validating provision details have been stored")
 				Expect(fakeStorage.StoreProvisionRequestDetailsCallCount()).To(Equal(1))
 				_, actualRequestVars := fakeStorage.StoreProvisionRequestDetailsArgsForCall(0)
-				Expect(actualRequestVars).To(Equal(json.RawMessage(`{"baz":"quz","foo":"quz","guz":"muz"}`)))
+				Expect(actualRequestVars).To(Equal(storage.JSONObject{"baz": "quz", "foo": "quz", "guz": "muz"}))
 			})
 		})
 
 		Describe("passing variables on provision, import and update", func() {
 			BeforeEach(func() {
-				fakeStorage.GetProvisionRequestDetailsReturns(json.RawMessage(`{"foo":"bar","baz":"quz"}`), nil)
+				fakeStorage.GetProvisionRequestDetailsReturns(map[string]interface{}{"foo": "bar", "baz": "quz"}, nil)
 				fakeServiceProvider.GetImportedPropertiesReturns(map[string]interface{}{"foo": "quz", "guz": "muz", "laz": "taz"}, nil)
 			})
 
@@ -345,7 +345,7 @@ var _ = Describe("Update", func() {
 				By("validating provision details have been stored")
 				Expect(fakeStorage.StoreProvisionRequestDetailsCallCount()).To(Equal(1))
 				_, actualRequestVars := fakeStorage.StoreProvisionRequestDetailsArgsForCall(0)
-				Expect(actualRequestVars).To(Equal(json.RawMessage(`{"baz":"quz","foo":"quz","guz":"duz","laz":"taz"}`)))
+				Expect(actualRequestVars).To(Equal(storage.JSONObject{"baz": "quz", "foo": "quz", "guz": "duz", "laz": "taz"}))
 			})
 		})
 
@@ -527,7 +527,7 @@ var _ = Describe("Update", func() {
 
 		Context("storage errors when getting provision parameters", func() {
 			BeforeEach(func() {
-				fakeStorage.GetProvisionRequestDetailsReturns(json.RawMessage{}, errors.New("failed to get provision parameters"))
+				fakeStorage.GetProvisionRequestDetailsReturns(nil, errors.New("failed to get provision parameters"))
 			})
 
 			It("should error", func() {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -153,8 +153,12 @@ func setupDBEncryption(db *gorm.DB, logger lager.Logger) storage.Encryptor {
 	err = storage.New(db, config.Encryptor).CheckAllRecords()
 	switch {
 	case err != nil:
-		// Note that this is not fatal because that would be a breaking change. But we do log errors that we find
-		// as they may prompt users to resolve them, and the log could be useful debugging other errors.
+		// This error denotes that there was a problem reading at least one database field.
+		// If you see this error, examine the rows and the error message and try to correct the data if you can.
+		// If there is data in the database that cannot be read, it may not be possible to update the service
+		// instance or service binding that it relates to. This may not be a problem in the short term, but in
+		// the longer term you should aim to delete the object. It may be necessary to raise an issue to get
+		// assistance with this.
 		logger.Error("database-field-error", err)
 	case len(config.ToDeleteLabels) > 0:
 		logger.Info("removing-state-password-metadata", lager.Data{"labels": config.ToDeleteLabels})

--- a/internal/paramparser/paramparser_suite_test.go
+++ b/internal/paramparser/paramparser_suite_test.go
@@ -1,0 +1,13 @@
+package paramparser_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestParamparser(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Paramparser Suite")
+}

--- a/internal/paramparser/parse_provision_details.go
+++ b/internal/paramparser/parse_provision_details.go
@@ -1,0 +1,48 @@
+package paramparser
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+)
+
+type ProvisionDetails struct {
+	ServiceID        string
+	PlanID           string
+	OrganizationGUID string
+	SpaceGUID        string
+	RequestParams    map[string]interface{}
+	RequestContext   map[string]interface{}
+}
+
+func ParseProvisionDetails(input domain.ProvisionDetails) (ProvisionDetails, error) {
+	result := ProvisionDetails{
+		ServiceID:        input.ServiceID,
+		PlanID:           input.PlanID,
+		OrganizationGUID: input.OrganizationGUID,
+		SpaceGUID:        input.SpaceGUID,
+	}
+
+	if len(input.RawParameters) > 0 {
+		if err := json.Unmarshal(input.RawParameters, &result.RequestParams); err != nil {
+			return ProvisionDetails{}, fmt.Errorf("error parsing request parameters: %w", err)
+		}
+	}
+
+	if len(input.RawContext) > 0 {
+		if err := json.Unmarshal(input.RawContext, &result.RequestContext); err != nil {
+			return ProvisionDetails{}, fmt.Errorf("error parsing request context: %w", err)
+		}
+	}
+
+	if s, ok := result.RequestContext["organization_guid"].(string); ok {
+		result.OrganizationGUID = s
+	}
+
+	if s, ok := result.RequestContext["space_guid"].(string); ok {
+		result.SpaceGUID = s
+	}
+
+	return result, nil
+}

--- a/internal/paramparser/parse_provision_details_test.go
+++ b/internal/paramparser/parse_provision_details_test.go
@@ -1,0 +1,106 @@
+package paramparser_test
+
+import (
+	"github.com/cloudfoundry/cloud-service-broker/internal/paramparser"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+)
+
+var _ = Describe("ParseProvisionDetails", func() {
+	It("can parse provision details", func() {
+		pd, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{
+			ServiceID:        "fake-service-id",
+			PlanID:           "fake-plan-id",
+			OrganizationGUID: "fake-org-guid",
+			SpaceGUID:        "fake-space-guid",
+			RawParameters:    []byte(`{"foo":"bar"}`),
+			RawContext:       []byte(`{"baz":"quz"}`),
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pd).To(Equal(paramparser.ProvisionDetails{
+			ServiceID:        "fake-service-id",
+			PlanID:           "fake-plan-id",
+			OrganizationGUID: "fake-org-guid",
+			SpaceGUID:        "fake-space-guid",
+			RequestParams:    map[string]interface{}{"foo": "bar"},
+			RequestContext:   map[string]interface{}{"baz": "quz"},
+		}))
+	})
+
+	When("params are not valid JSON", func() {
+		It("returns an error", func() {
+			pd, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{
+				RawParameters: []byte(`not-json`),
+			})
+
+			Expect(err).To(MatchError(`error parsing request parameters: invalid character 'o' in literal null (expecting 'u')`))
+			Expect(pd).To(BeZero())
+		})
+	})
+
+	When("context is not valid JSON", func() {
+		It("returns an error", func() {
+			pd, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{
+				RawContext: []byte(`not-json`),
+			})
+
+			Expect(err).To(MatchError(`error parsing request context: invalid character 'o' in literal null (expecting 'u')`))
+			Expect(pd).To(BeZero())
+		})
+	})
+
+	When("input is empty", func() {
+		It("succeeds with an empty result", func() {
+			pd, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pd).To(BeZero())
+		})
+	})
+
+	When("org guid is in context", func() {
+		It("takes a string value from context", func() {
+			pd, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{
+				OrganizationGUID: "fake-org-guid-1",
+				RawContext:       []byte(`{"organization_guid":"fake-org-guid-2"}`),
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pd.OrganizationGUID).To(Equal("fake-org-guid-2"))
+		})
+
+		It("ignores a non-string value from the context", func() {
+			pd, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{
+				OrganizationGUID: "fake-org-guid-1",
+				RawContext:       []byte(`{"organization_guid":["fake-org-guid-2"]}`),
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pd.OrganizationGUID).To(Equal("fake-org-guid-1"))
+		})
+	})
+
+	When("space guid is in context", func() {
+		It("takes a string value from context", func() {
+			pd, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{
+				SpaceGUID:  "fake-space-guid-1",
+				RawContext: []byte(`{"space_guid":"fake-space-guid-2"}`),
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pd.SpaceGUID).To(Equal("fake-space-guid-2"))
+		})
+
+		It("ignores a non-string value from the context", func() {
+			pd, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{
+				SpaceGUID:  "fake-space-guid-1",
+				RawContext: []byte(`{"space_guid":["fake-space-guid-2"]}`),
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pd.SpaceGUID).To(Equal("fake-space-guid-1"))
+		})
+	})
+})

--- a/internal/paramparser/parse_update_details.go
+++ b/internal/paramparser/parse_update_details.go
@@ -1,0 +1,44 @@
+package paramparser
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+)
+
+type UpdateDetails struct {
+	ServiceID         string
+	PlanID            string
+	PreviousPlanID    string
+	PreviousServiceID string
+	PreviousOrgID     string
+	PreviousSpaceID   string
+	RequestParams     map[string]interface{}
+	RequestContext    map[string]interface{}
+}
+
+func ParseUpdateDetails(input domain.UpdateDetails) (UpdateDetails, error) {
+	result := UpdateDetails{
+		ServiceID:         input.ServiceID,
+		PlanID:            input.PlanID,
+		PreviousPlanID:    input.PreviousValues.PlanID,
+		PreviousServiceID: input.PreviousValues.ServiceID,
+		PreviousOrgID:     input.PreviousValues.OrgID,
+		PreviousSpaceID:   input.PreviousValues.SpaceID,
+	}
+
+	if len(input.RawParameters) > 0 {
+		if err := json.Unmarshal(input.RawParameters, &result.RequestParams); err != nil {
+			return UpdateDetails{}, fmt.Errorf("error parsing request parameters: %w", err)
+		}
+	}
+
+	if len(input.RawContext) > 0 {
+		if err := json.Unmarshal(input.RawContext, &result.RequestContext); err != nil {
+			return UpdateDetails{}, fmt.Errorf("error parsing request context: %w", err)
+		}
+	}
+
+	return result, nil
+}

--- a/internal/paramparser/parse_update_details_test.go
+++ b/internal/paramparser/parse_update_details_test.go
@@ -1,0 +1,68 @@
+package paramparser_test
+
+import (
+	"github.com/cloudfoundry/cloud-service-broker/internal/paramparser"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+)
+
+var _ = Describe("ParseUpdateDetails", func() {
+	It("can parse update details", func() {
+		ud, err := paramparser.ParseUpdateDetails(domain.UpdateDetails{
+			ServiceID:     "fake-service-id",
+			PlanID:        "fake-plan-id",
+			RawParameters: []byte(`{"foo":"bar"}`),
+			PreviousValues: domain.PreviousValues{
+				PlanID:    "fake-previous-plan-id",
+				ServiceID: "fake-previous-service-id",
+				OrgID:     "fake-previous-org-id",
+				SpaceID:   "fake-previous-space-id",
+			},
+			RawContext: []byte(`{"baz":"quz"}`),
+		})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ud).To(Equal(paramparser.UpdateDetails{
+			ServiceID:         "fake-service-id",
+			PlanID:            "fake-plan-id",
+			RequestParams:     map[string]interface{}{"foo": "bar"},
+			RequestContext:    map[string]interface{}{"baz": "quz"},
+			PreviousPlanID:    "fake-previous-plan-id",
+			PreviousServiceID: "fake-previous-service-id",
+			PreviousOrgID:     "fake-previous-org-id",
+			PreviousSpaceID:   "fake-previous-space-id",
+		}))
+	})
+
+	When("params are not valid JSON", func() {
+		It("returns an error", func() {
+			ud, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{
+				RawParameters: []byte(`not-json`),
+			})
+
+			Expect(err).To(MatchError(`error parsing request parameters: invalid character 'o' in literal null (expecting 'u')`))
+			Expect(ud).To(BeZero())
+		})
+	})
+
+	When("context is not valid JSON", func() {
+		It("returns an error", func() {
+			ud, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{
+				RawContext: []byte(`not-json`),
+			})
+
+			Expect(err).To(MatchError(`error parsing request context: invalid character 'o' in literal null (expecting 'u')`))
+			Expect(ud).To(BeZero())
+		})
+	})
+
+	When("input is empty", func() {
+		It("succeeds with an empty result", func() {
+			ud, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ud).To(BeZero())
+		})
+	})
+})

--- a/internal/storage/check_all_records.go
+++ b/internal/storage/check_all_records.go
@@ -70,7 +70,7 @@ func (s *Storage) checkAllProvisionRequestDetails() (errs *multierror.Error) {
 	var provisionRequestDetailsBatch []models.ProvisionRequestDetails
 	result := s.db.FindInBatches(&provisionRequestDetailsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
 		for i := range provisionRequestDetailsBatch {
-			_, err := s.decodeBytes(provisionRequestDetailsBatch[i].RequestDetails)
+			_, err := s.decodeJSONObject(provisionRequestDetailsBatch[i].RequestDetails)
 			if err != nil {
 				errs = multierror.Append(fmt.Errorf("decode error for provision request details %q: %w", provisionRequestDetailsBatch[i].ServiceInstanceId, err), errs)
 			}

--- a/internal/storage/check_all_records_test.go
+++ b/internal/storage/check_all_records_test.go
@@ -9,8 +9,6 @@ import (
 var _ = Describe("CheckAllRecords", func() {
 
 	BeforeEach(func() {
-		//encryptor = &storagefakes.FakeEncryptor{}
-
 		addFakeServiceCredentialBindings()
 		addFakeProvisionRequestDetails()
 		addFakeBindRequestDetails()
@@ -40,7 +38,12 @@ var _ = Describe("CheckAllRecords", func() {
 
 			Expect(db.Create(&models.ProvisionRequestDetails{
 				RequestDetails:    []byte(`cannot-be-decrypted`),
-				ServiceInstanceId: "fake-bad-instance-id",
+				ServiceInstanceId: "fake-bad-instance-id-1",
+			}).Error).NotTo(HaveOccurred())
+
+			Expect(db.Create(&models.ProvisionRequestDetails{
+				RequestDetails:    []byte(`request-details-not-json`),
+				ServiceInstanceId: "fake-bad-instance-id-2",
 			}).Error).NotTo(HaveOccurred())
 
 			Expect(db.Create(&models.BindRequestDetails{
@@ -72,7 +75,8 @@ var _ = Describe("CheckAllRecords", func() {
 			Expect(store.CheckAllRecords()).To(MatchError(And(
 				ContainSubstring(`decode error for service binding credential "fake-bad-binding-id-1": JSON parse error: invalid character 'b' looking for beginning of value`),
 				ContainSubstring(`decode error for service binding credential "fake-bad-binding-id-2": decryption error: fake decryption error`),
-				ContainSubstring(`decode error for provision request details "fake-bad-instance-id": decryption error: fake decryption error`),
+				ContainSubstring(`decode error for provision request details "fake-bad-instance-id-1": decryption error: fake decryption error`),
+				ContainSubstring(`decode error for provision request details "fake-bad-instance-id-2": JSON parse error: invalid character 'r' looking for beginning of value`),
 				ContainSubstring(`decode error for binding request details "fake-bad-binding-id": decryption error: fake decryption error`),
 				ContainSubstring(`decode error for service instance details "fake-bad-instance-id-1": JSON parse error: invalid character 's' looking for beginning of value`),
 				ContainSubstring(`decode error for service instance details "fake-bad-instance-id-2": decryption error: fake decryption error`),

--- a/internal/storage/encode.go
+++ b/internal/storage/encode.go
@@ -32,7 +32,7 @@ func (s *Storage) decodeBytes(a []byte) ([]byte, error) {
 	return d, nil
 }
 
-func (s *Storage) decodeJSONObject(a []byte) (map[string]interface{}, error) {
+func (s *Storage) decodeJSONObject(a []byte) (JSONObject, error) {
 	b, err := s.decodeBytes(a)
 	switch {
 	case err != nil:
@@ -41,7 +41,7 @@ func (s *Storage) decodeJSONObject(a []byte) (map[string]interface{}, error) {
 		return nil, nil
 	}
 
-	var receiver map[string]interface{}
+	var receiver JSONObject
 	if err := json.Unmarshal(b, &receiver); err != nil {
 		return nil, fmt.Errorf("JSON parse error: %w", err)
 	}

--- a/internal/storage/provision_request_details.go
+++ b/internal/storage/provision_request_details.go
@@ -1,19 +1,13 @@
 package storage
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/cloudfoundry/cloud-service-broker/db_service/models"
 )
 
-type ProvisionRequestDetails struct {
-	ServiceInstanceGUID string
-	RequestDetails      []byte
-}
-
-func (s *Storage) StoreProvisionRequestDetails(serviceInstanceID string, details json.RawMessage) error {
-	encoded, err := s.encodeBytes(details)
+func (s *Storage) StoreProvisionRequestDetails(serviceInstanceID string, details JSONObject) error {
+	encoded, err := s.encodeJSON(details)
 	if err != nil {
 		return fmt.Errorf("error encoding details: %w", err)
 	}
@@ -41,7 +35,7 @@ func (s *Storage) StoreProvisionRequestDetails(serviceInstanceID string, details
 	return nil
 }
 
-func (s *Storage) GetProvisionRequestDetails(serviceInstanceID string) (json.RawMessage, error) {
+func (s *Storage) GetProvisionRequestDetails(serviceInstanceID string) (JSONObject, error) {
 	exists, err := s.existsProvisionRequestDetails(serviceInstanceID)
 	switch {
 	case err != nil:
@@ -55,7 +49,7 @@ func (s *Storage) GetProvisionRequestDetails(serviceInstanceID string) (json.Raw
 		return nil, fmt.Errorf("error finding provision request details record: %w", err)
 	}
 
-	decoded, err := s.decodeBytes(receiver.RequestDetails)
+	decoded, err := s.decodeJSONObject(receiver.RequestDetails)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding provision request details %q: %w", serviceInstanceID, err)
 	}

--- a/internal/storage/service_binding_credentials.go
+++ b/internal/storage/service_binding_credentials.go
@@ -6,13 +6,11 @@ import (
 	"github.com/cloudfoundry/cloud-service-broker/db_service/models"
 )
 
-type Credentials map[string]interface{}
-
 type ServiceBindingCredentials struct {
 	ServiceGUID         string
 	ServiceInstanceGUID string
 	BindingGUID         string
-	Credentials         Credentials
+	Credentials         JSONObject
 }
 
 func (s *Storage) CreateServiceBindingCredentials(binding ServiceBindingCredentials) error {

--- a/internal/storage/service_binding_credentials_test.go
+++ b/internal/storage/service_binding_credentials_test.go
@@ -16,7 +16,7 @@ var _ = Describe("ServiceBindingCredentials", func() {
 				ServiceGUID:         "fake-service-id",
 				ServiceInstanceGUID: "fake-instance-id",
 				BindingGUID:         "fake-binding-id",
-				Credentials: storage.Credentials{
+				Credentials: storage.JSONObject{
 					"fake-cred-1": "fake-val-1",
 					"fake-cred-2": "fake-val-2",
 				},
@@ -57,7 +57,7 @@ var _ = Describe("ServiceBindingCredentials", func() {
 			Expect(r.ServiceGUID).To(Equal("fake-service-id"))
 			Expect(r.ServiceInstanceGUID).To(Equal("fake-instance-id"))
 			Expect(r.BindingGUID).To(Equal("fake-binding-id"))
-			Expect(r.Credentials).To(Equal(storage.Credentials{
+			Expect(r.Credentials).To(Equal(storage.JSONObject{
 				"decrypted": map[string]interface{}{
 					"foo": "baz",
 					"bar": "quz",

--- a/internal/storage/service_instance_details.go
+++ b/internal/storage/service_instance_details.go
@@ -6,14 +6,12 @@ import (
 	"github.com/cloudfoundry/cloud-service-broker/db_service/models"
 )
 
-type TerraformOutputs map[string]interface{}
-
 type ServiceInstanceDetails struct {
 	GUID             string
 	Name             string
 	Location         string
 	URL              string
-	Outputs          TerraformOutputs
+	Outputs          JSONObject
 	ServiceGUID      string
 	PlanGUID         string
 	SpaceGUID        string

--- a/internal/storage/service_instance_details_test.go
+++ b/internal/storage/service_instance_details_test.go
@@ -3,9 +3,8 @@ package storage_test
 import (
 	"errors"
 
-	"github.com/cloudfoundry/cloud-service-broker/internal/storage"
-
 	"github.com/cloudfoundry/cloud-service-broker/db_service/models"
+	"github.com/cloudfoundry/cloud-service-broker/internal/storage"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -102,7 +101,7 @@ var _ = Describe("ServiceInstanceDetails", func() {
 			Expect(r.GUID).To(Equal("fake-id-2"))
 			Expect(r.Location).To(Equal("fake-location-2"))
 			Expect(r.URL).To(Equal("fake-url-2"))
-			Expect(r.Outputs).To(Equal(storage.TerraformOutputs{"decrypted": map[string]interface{}{"foo": "bar-2"}}))
+			Expect(r.Outputs).To(Equal(storage.JSONObject{"decrypted": map[string]interface{}{"foo": "bar-2"}}))
 			Expect(r.ServiceGUID).To(Equal("fake-service-id-2"))
 			Expect(r.PlanGUID).To(Equal("fake-plan-id-2"))
 			Expect(r.SpaceGUID).To(Equal("fake-space-guid-2"))

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -13,3 +13,5 @@ func New(db *gorm.DB, encryptor Encryptor) *Storage {
 		encryptor: encryptor,
 	}
 }
+
+type JSONObject map[string]interface{}

--- a/pkg/broker/brokerfakes/fake_service_provider.go
+++ b/pkg/broker/brokerfakes/fake_service_provider.go
@@ -27,12 +27,12 @@ type FakeServiceProvider struct {
 		result1 map[string]interface{}
 		result2 error
 	}
-	BuildInstanceCredentialsStub        func(context.Context, map[string]interface{}, storage.TerraformOutputs) (*domain.Binding, error)
+	BuildInstanceCredentialsStub        func(context.Context, map[string]interface{}, storage.JSONObject) (*domain.Binding, error)
 	buildInstanceCredentialsMutex       sync.RWMutex
 	buildInstanceCredentialsArgsForCall []struct {
 		arg1 context.Context
 		arg2 map[string]interface{}
-		arg3 storage.TerraformOutputs
+		arg3 storage.JSONObject
 	}
 	buildInstanceCredentialsReturns struct {
 		result1 *domain.Binding
@@ -84,18 +84,18 @@ type FakeServiceProvider struct {
 		result1 map[string]interface{}
 		result2 error
 	}
-	GetTerraformOutputsStub        func(context.Context, string) (storage.TerraformOutputs, error)
+	GetTerraformOutputsStub        func(context.Context, string) (storage.JSONObject, error)
 	getTerraformOutputsMutex       sync.RWMutex
 	getTerraformOutputsArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
 	}
 	getTerraformOutputsReturns struct {
-		result1 storage.TerraformOutputs
+		result1 storage.JSONObject
 		result2 error
 	}
 	getTerraformOutputsReturnsOnCall map[int]struct {
-		result1 storage.TerraformOutputs
+		result1 storage.JSONObject
 		result2 error
 	}
 	PollInstanceStub        func(context.Context, string) (bool, string, error)
@@ -235,13 +235,13 @@ func (fake *FakeServiceProvider) BindReturnsOnCall(i int, result1 map[string]int
 	}{result1, result2}
 }
 
-func (fake *FakeServiceProvider) BuildInstanceCredentials(arg1 context.Context, arg2 map[string]interface{}, arg3 storage.TerraformOutputs) (*domain.Binding, error) {
+func (fake *FakeServiceProvider) BuildInstanceCredentials(arg1 context.Context, arg2 map[string]interface{}, arg3 storage.JSONObject) (*domain.Binding, error) {
 	fake.buildInstanceCredentialsMutex.Lock()
 	ret, specificReturn := fake.buildInstanceCredentialsReturnsOnCall[len(fake.buildInstanceCredentialsArgsForCall)]
 	fake.buildInstanceCredentialsArgsForCall = append(fake.buildInstanceCredentialsArgsForCall, struct {
 		arg1 context.Context
 		arg2 map[string]interface{}
-		arg3 storage.TerraformOutputs
+		arg3 storage.JSONObject
 	}{arg1, arg2, arg3})
 	stub := fake.BuildInstanceCredentialsStub
 	fakeReturns := fake.buildInstanceCredentialsReturns
@@ -262,13 +262,13 @@ func (fake *FakeServiceProvider) BuildInstanceCredentialsCallCount() int {
 	return len(fake.buildInstanceCredentialsArgsForCall)
 }
 
-func (fake *FakeServiceProvider) BuildInstanceCredentialsCalls(stub func(context.Context, map[string]interface{}, storage.TerraformOutputs) (*domain.Binding, error)) {
+func (fake *FakeServiceProvider) BuildInstanceCredentialsCalls(stub func(context.Context, map[string]interface{}, storage.JSONObject) (*domain.Binding, error)) {
 	fake.buildInstanceCredentialsMutex.Lock()
 	defer fake.buildInstanceCredentialsMutex.Unlock()
 	fake.BuildInstanceCredentialsStub = stub
 }
 
-func (fake *FakeServiceProvider) BuildInstanceCredentialsArgsForCall(i int) (context.Context, map[string]interface{}, storage.TerraformOutputs) {
+func (fake *FakeServiceProvider) BuildInstanceCredentialsArgsForCall(i int) (context.Context, map[string]interface{}, storage.JSONObject) {
 	fake.buildInstanceCredentialsMutex.RLock()
 	defer fake.buildInstanceCredentialsMutex.RUnlock()
 	argsForCall := fake.buildInstanceCredentialsArgsForCall[i]
@@ -493,7 +493,7 @@ func (fake *FakeServiceProvider) GetImportedPropertiesReturnsOnCall(i int, resul
 	}{result1, result2}
 }
 
-func (fake *FakeServiceProvider) GetTerraformOutputs(arg1 context.Context, arg2 string) (storage.TerraformOutputs, error) {
+func (fake *FakeServiceProvider) GetTerraformOutputs(arg1 context.Context, arg2 string) (storage.JSONObject, error) {
 	fake.getTerraformOutputsMutex.Lock()
 	ret, specificReturn := fake.getTerraformOutputsReturnsOnCall[len(fake.getTerraformOutputsArgsForCall)]
 	fake.getTerraformOutputsArgsForCall = append(fake.getTerraformOutputsArgsForCall, struct {
@@ -519,7 +519,7 @@ func (fake *FakeServiceProvider) GetTerraformOutputsCallCount() int {
 	return len(fake.getTerraformOutputsArgsForCall)
 }
 
-func (fake *FakeServiceProvider) GetTerraformOutputsCalls(stub func(context.Context, string) (storage.TerraformOutputs, error)) {
+func (fake *FakeServiceProvider) GetTerraformOutputsCalls(stub func(context.Context, string) (storage.JSONObject, error)) {
 	fake.getTerraformOutputsMutex.Lock()
 	defer fake.getTerraformOutputsMutex.Unlock()
 	fake.GetTerraformOutputsStub = stub
@@ -532,28 +532,28 @@ func (fake *FakeServiceProvider) GetTerraformOutputsArgsForCall(i int) (context.
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeServiceProvider) GetTerraformOutputsReturns(result1 storage.TerraformOutputs, result2 error) {
+func (fake *FakeServiceProvider) GetTerraformOutputsReturns(result1 storage.JSONObject, result2 error) {
 	fake.getTerraformOutputsMutex.Lock()
 	defer fake.getTerraformOutputsMutex.Unlock()
 	fake.GetTerraformOutputsStub = nil
 	fake.getTerraformOutputsReturns = struct {
-		result1 storage.TerraformOutputs
+		result1 storage.JSONObject
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeServiceProvider) GetTerraformOutputsReturnsOnCall(i int, result1 storage.TerraformOutputs, result2 error) {
+func (fake *FakeServiceProvider) GetTerraformOutputsReturnsOnCall(i int, result1 storage.JSONObject, result2 error) {
 	fake.getTerraformOutputsMutex.Lock()
 	defer fake.getTerraformOutputsMutex.Unlock()
 	fake.GetTerraformOutputsStub = nil
 	if fake.getTerraformOutputsReturnsOnCall == nil {
 		fake.getTerraformOutputsReturnsOnCall = make(map[int]struct {
-			result1 storage.TerraformOutputs
+			result1 storage.JSONObject
 			result2 error
 		})
 	}
 	fake.getTerraformOutputsReturnsOnCall[i] = struct {
-		result1 storage.TerraformOutputs
+		result1 storage.JSONObject
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/broker/service_definition_test.go
+++ b/pkg/broker/service_definition_test.go
@@ -1,8 +1,6 @@
 package broker_test
 
 import (
-	"encoding/json"
-
 	"github.com/cloudfoundry/cloud-service-broker/pkg/broker"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/varcontext"
 	. "github.com/onsi/ginkgo/v2"
@@ -244,26 +242,14 @@ var _ = Describe("ServiceDefinition", func() {
 		}
 
 		DescribeTable("returns the correct result",
-			func(rawParams string, expected bool) {
-				actual, err := serviceDefinition.AllowedUpdate(
-					domain.UpdateDetails{
-						RawParameters: json.RawMessage(rawParams),
-					})
+			func(params map[string]interface{}, expected bool) {
+				actual, err := serviceDefinition.AllowedUpdate(params)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(actual).To(Equal(expected))
 			},
-			Entry("allowed", `{"allowed":"some_val"}`, true),
-			Entry("prohibited", `{"prohibited":"some_val"}`, false),
-			Entry("empty", "", true),
+			Entry("allowed", map[string]interface{}{"allowed": "some_val"}, true),
+			Entry("prohibited", map[string]interface{}{"prohibited": "some_val"}, false),
+			Entry("empty", nil, true),
 		)
-
-		It("should error when it receives bed json", func() {
-			_, err := serviceDefinition.AllowedUpdate(
-				domain.UpdateDetails{
-					RawParameters: json.RawMessage(`{"bogus"}`),
-				})
-			Expect(err).To(MatchError("invalid character '}' after object key"))
-		})
-
 	})
 })

--- a/pkg/broker/service_provider.go
+++ b/pkg/broker/service_provider.go
@@ -47,7 +47,7 @@ type ServiceProvider interface {
 	Bind(ctx context.Context, vc *varcontext.VarContext) (map[string]interface{}, error)
 	// BuildInstanceCredentials combines the bindRecord with any additional
 	// info from the instance to create credentials for the binding.
-	BuildInstanceCredentials(ctx context.Context, credentials map[string]interface{}, outputs storage.TerraformOutputs) (*domain.Binding, error)
+	BuildInstanceCredentials(ctx context.Context, credentials map[string]interface{}, outputs storage.JSONObject) (*domain.Binding, error)
 	// Unbind deprovisions the resources created with Bind.
 	Unbind(ctx context.Context, instanceGUID, bindingID string, vc *varcontext.VarContext) error
 	// Deprovision deprovisions the service.
@@ -62,7 +62,7 @@ type ServiceProvider interface {
 	// This function is optional, but will be called after async provisions, updates, and possibly
 	// on broker version changes.
 	// Return a nil error if you choose not to implement this function.
-	GetTerraformOutputs(ctx context.Context, guid string) (storage.TerraformOutputs, error)
+	GetTerraformOutputs(ctx context.Context, guid string) (storage.JSONObject, error)
 }
 
 //counterfeiter:generate . ServiceProviderStorage

--- a/pkg/providers/builtin/base/mixins.go
+++ b/pkg/providers/builtin/base/mixins.go
@@ -28,7 +28,7 @@ type MergedInstanceCredsMixin struct{}
 
 // BuildInstanceCredentials combines the bind credentials with the connection
 // information in the instance details to get a full set of connection details.
-func (b *MergedInstanceCredsMixin) BuildInstanceCredentials(ctx context.Context, credentials map[string]interface{}, outputs storage.TerraformOutputs) (*domain.Binding, error) {
+func (b *MergedInstanceCredsMixin) BuildInstanceCredentials(ctx context.Context, credentials map[string]interface{}, outputs storage.JSONObject) (*domain.Binding, error) {
 	vc, err := varcontext.Builder().
 		MergeMap(outputs).
 		MergeMap(credentials).

--- a/pkg/providers/tf/provider.go
+++ b/pkg/providers/tf/provider.go
@@ -272,7 +272,7 @@ func (provider *terraformProvider) DeprovisionsAsync() bool {
 // This function is optional, but will be called after async provisions, updates, and possibly
 // on broker version changes.
 // Return a nil error if you choose not to implement this function.
-func (provider *terraformProvider) GetTerraformOutputs(ctx context.Context, guid string) (storage.TerraformOutputs, error) {
+func (provider *terraformProvider) GetTerraformOutputs(ctx context.Context, guid string) (storage.JSONObject, error) {
 	tfId := generateTfId(guid, "")
 
 	outs, err := provider.jobRunner.Outputs(ctx, tfId, wrapper.DefaultInstanceName)

--- a/pkg/providers/tf/tffakes/fake_workspace.go
+++ b/pkg/providers/tf/tffakes/fake_workspace.go
@@ -26,7 +26,6 @@ type FakeWorkspace struct {
 		result1 wrapper.ExecutionOutput
 		result2 error
 	}
-<<<<<<< HEAD
 	HasStateStub        func() bool
 	hasStateMutex       sync.RWMutex
 	hasStateArgsForCall []struct {
@@ -37,22 +36,6 @@ type FakeWorkspace struct {
 	hasStateReturnsOnCall map[int]struct {
 		result1 bool
 	}
-||||||| parent of 5296fa1d (chore: parse provision request details in storage layer)
-	ImportStub        func(context.Context, wrapper.TerraformExecutor, map[string]string) error
-	importMutex       sync.RWMutex
-	importArgsForCall []struct {
-		arg1 context.Context
-		arg2 wrapper.TerraformExecutor
-		arg3 map[string]string
-	}
-	importReturns struct {
-		result1 error
-	}
-	importReturnsOnCall map[int]struct {
-		result1 error
-	}
-=======
->>>>>>> 5296fa1d (chore: parse provision request details in storage layer)
 	ModuleDefinitionsStub        func() []wrapper.ModuleDefinition
 	moduleDefinitionsMutex       sync.RWMutex
 	moduleDefinitionsArgsForCall []struct {
@@ -191,7 +174,6 @@ func (fake *FakeWorkspace) ExecuteReturnsOnCall(i int, result1 wrapper.Execution
 	}{result1, result2}
 }
 
-<<<<<<< HEAD
 func (fake *FakeWorkspace) HasState() bool {
 	fake.hasStateMutex.Lock()
 	ret, specificReturn := fake.hasStateReturnsOnCall[len(fake.hasStateArgsForCall)]
@@ -245,72 +227,6 @@ func (fake *FakeWorkspace) HasStateReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
-||||||| parent of 5296fa1d (chore: parse provision request details in storage layer)
-func (fake *FakeWorkspace) Import(arg1 context.Context, arg2 wrapper.TerraformExecutor, arg3 map[string]string) error {
-	fake.importMutex.Lock()
-	ret, specificReturn := fake.importReturnsOnCall[len(fake.importArgsForCall)]
-	fake.importArgsForCall = append(fake.importArgsForCall, struct {
-		arg1 context.Context
-		arg2 wrapper.TerraformExecutor
-		arg3 map[string]string
-	}{arg1, arg2, arg3})
-	stub := fake.ImportStub
-	fakeReturns := fake.importReturns
-	fake.recordInvocation("Import", []interface{}{arg1, arg2, arg3})
-	fake.importMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeWorkspace) ImportCallCount() int {
-	fake.importMutex.RLock()
-	defer fake.importMutex.RUnlock()
-	return len(fake.importArgsForCall)
-}
-
-func (fake *FakeWorkspace) ImportCalls(stub func(context.Context, wrapper.TerraformExecutor, map[string]string) error) {
-	fake.importMutex.Lock()
-	defer fake.importMutex.Unlock()
-	fake.ImportStub = stub
-}
-
-func (fake *FakeWorkspace) ImportArgsForCall(i int) (context.Context, wrapper.TerraformExecutor, map[string]string) {
-	fake.importMutex.RLock()
-	defer fake.importMutex.RUnlock()
-	argsForCall := fake.importArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
-}
-
-func (fake *FakeWorkspace) ImportReturns(result1 error) {
-	fake.importMutex.Lock()
-	defer fake.importMutex.Unlock()
-	fake.ImportStub = nil
-	fake.importReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeWorkspace) ImportReturnsOnCall(i int, result1 error) {
-	fake.importMutex.Lock()
-	defer fake.importMutex.Unlock()
-	fake.ImportStub = nil
-	if fake.importReturnsOnCall == nil {
-		fake.importReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.importReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-=======
->>>>>>> 5296fa1d (chore: parse provision request details in storage layer)
 func (fake *FakeWorkspace) ModuleDefinitions() []wrapper.ModuleDefinition {
 	fake.moduleDefinitionsMutex.Lock()
 	ret, specificReturn := fake.moduleDefinitionsReturnsOnCall[len(fake.moduleDefinitionsArgsForCall)]
@@ -659,14 +575,8 @@ func (fake *FakeWorkspace) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.executeMutex.RLock()
 	defer fake.executeMutex.RUnlock()
-<<<<<<< HEAD
 	fake.hasStateMutex.RLock()
 	defer fake.hasStateMutex.RUnlock()
-||||||| parent of 5296fa1d (chore: parse provision request details in storage layer)
-	fake.importMutex.RLock()
-	defer fake.importMutex.RUnlock()
-=======
->>>>>>> 5296fa1d (chore: parse provision request details in storage layer)
 	fake.moduleDefinitionsMutex.RLock()
 	defer fake.moduleDefinitionsMutex.RUnlock()
 	fake.moduleInstancesMutex.RLock()

--- a/pkg/providers/tf/tffakes/fake_workspace.go
+++ b/pkg/providers/tf/tffakes/fake_workspace.go
@@ -26,6 +26,7 @@ type FakeWorkspace struct {
 		result1 wrapper.ExecutionOutput
 		result2 error
 	}
+<<<<<<< HEAD
 	HasStateStub        func() bool
 	hasStateMutex       sync.RWMutex
 	hasStateArgsForCall []struct {
@@ -36,6 +37,22 @@ type FakeWorkspace struct {
 	hasStateReturnsOnCall map[int]struct {
 		result1 bool
 	}
+||||||| parent of 5296fa1d (chore: parse provision request details in storage layer)
+	ImportStub        func(context.Context, wrapper.TerraformExecutor, map[string]string) error
+	importMutex       sync.RWMutex
+	importArgsForCall []struct {
+		arg1 context.Context
+		arg2 wrapper.TerraformExecutor
+		arg3 map[string]string
+	}
+	importReturns struct {
+		result1 error
+	}
+	importReturnsOnCall map[int]struct {
+		result1 error
+	}
+=======
+>>>>>>> 5296fa1d (chore: parse provision request details in storage layer)
 	ModuleDefinitionsStub        func() []wrapper.ModuleDefinition
 	moduleDefinitionsMutex       sync.RWMutex
 	moduleDefinitionsArgsForCall []struct {
@@ -174,6 +191,7 @@ func (fake *FakeWorkspace) ExecuteReturnsOnCall(i int, result1 wrapper.Execution
 	}{result1, result2}
 }
 
+<<<<<<< HEAD
 func (fake *FakeWorkspace) HasState() bool {
 	fake.hasStateMutex.Lock()
 	ret, specificReturn := fake.hasStateReturnsOnCall[len(fake.hasStateArgsForCall)]
@@ -227,6 +245,72 @@ func (fake *FakeWorkspace) HasStateReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
+||||||| parent of 5296fa1d (chore: parse provision request details in storage layer)
+func (fake *FakeWorkspace) Import(arg1 context.Context, arg2 wrapper.TerraformExecutor, arg3 map[string]string) error {
+	fake.importMutex.Lock()
+	ret, specificReturn := fake.importReturnsOnCall[len(fake.importArgsForCall)]
+	fake.importArgsForCall = append(fake.importArgsForCall, struct {
+		arg1 context.Context
+		arg2 wrapper.TerraformExecutor
+		arg3 map[string]string
+	}{arg1, arg2, arg3})
+	stub := fake.ImportStub
+	fakeReturns := fake.importReturns
+	fake.recordInvocation("Import", []interface{}{arg1, arg2, arg3})
+	fake.importMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeWorkspace) ImportCallCount() int {
+	fake.importMutex.RLock()
+	defer fake.importMutex.RUnlock()
+	return len(fake.importArgsForCall)
+}
+
+func (fake *FakeWorkspace) ImportCalls(stub func(context.Context, wrapper.TerraformExecutor, map[string]string) error) {
+	fake.importMutex.Lock()
+	defer fake.importMutex.Unlock()
+	fake.ImportStub = stub
+}
+
+func (fake *FakeWorkspace) ImportArgsForCall(i int) (context.Context, wrapper.TerraformExecutor, map[string]string) {
+	fake.importMutex.RLock()
+	defer fake.importMutex.RUnlock()
+	argsForCall := fake.importArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeWorkspace) ImportReturns(result1 error) {
+	fake.importMutex.Lock()
+	defer fake.importMutex.Unlock()
+	fake.ImportStub = nil
+	fake.importReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeWorkspace) ImportReturnsOnCall(i int, result1 error) {
+	fake.importMutex.Lock()
+	defer fake.importMutex.Unlock()
+	fake.ImportStub = nil
+	if fake.importReturnsOnCall == nil {
+		fake.importReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.importReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+=======
+>>>>>>> 5296fa1d (chore: parse provision request details in storage layer)
 func (fake *FakeWorkspace) ModuleDefinitions() []wrapper.ModuleDefinition {
 	fake.moduleDefinitionsMutex.Lock()
 	ret, specificReturn := fake.moduleDefinitionsReturnsOnCall[len(fake.moduleDefinitionsArgsForCall)]
@@ -575,8 +659,14 @@ func (fake *FakeWorkspace) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.executeMutex.RLock()
 	defer fake.executeMutex.RUnlock()
+<<<<<<< HEAD
 	fake.hasStateMutex.RLock()
 	defer fake.hasStateMutex.RUnlock()
+||||||| parent of 5296fa1d (chore: parse provision request details in storage layer)
+	fake.importMutex.RLock()
+	defer fake.importMutex.RUnlock()
+=======
+>>>>>>> 5296fa1d (chore: parse provision request details in storage layer)
 	fake.moduleDefinitionsMutex.RLock()
 	defer fake.moduleDefinitionsMutex.RUnlock()
 	fake.moduleInstancesMutex.RLock()

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -15,13 +15,10 @@
 package utils
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
 	"testing"
-
-	"github.com/pivotal-cf/brokerapi/v8/domain"
 )
 
 func ExamplePropertyToEnv() {
@@ -85,63 +82,6 @@ func ExampleGetDefaultProjectId() {
 	fmt.Printf("%s, %v\n", projectId, err)
 
 	// Output: my-project-123, <nil>
-}
-
-func TestExtractDefaultProvisionLabels(t *testing.T) {
-	tests := map[string]struct {
-		instanceId string
-		details    domain.ProvisionDetails
-		expected   map[string]string
-	}{
-		"empty everything": {
-			instanceId: "",
-			details:    domain.ProvisionDetails{},
-			expected: map[string]string{
-				"pcf-organization-guid": "",
-				"pcf-space-guid":        "",
-				"pcf-instance-id":       "",
-			},
-		},
-		"osb 2.13": {
-			instanceId: "my-instance",
-			details:    domain.ProvisionDetails{OrganizationGUID: "org-guid", SpaceGUID: "space-guid"},
-			expected: map[string]string{
-				"pcf-organization-guid": "org-guid",
-				"pcf-space-guid":        "space-guid",
-				"pcf-instance-id":       "my-instance",
-			},
-		},
-		"osb future": {
-			instanceId: "my-instance",
-			details: domain.ProvisionDetails{
-				OrganizationGUID: "org-guid",
-				SpaceGUID:        "space-guid",
-				RawContext:       json.RawMessage(`{"organization_guid":"org-override", "space_guid":"space-override"}`),
-			},
-			expected: map[string]string{
-				"pcf-organization-guid": "org-override",
-				"pcf-space-guid":        "space-override",
-				"pcf-instance-id":       "my-instance",
-			},
-		},
-		"osb special characters": {
-			instanceId: "my~instance.",
-			details:    domain.ProvisionDetails{},
-			expected: map[string]string{
-				"pcf-organization-guid": "",
-				"pcf-space-guid":        "",
-				"pcf-instance-id":       "my_instance_",
-			},
-		},
-	}
-
-	for tn, tc := range tests {
-		labels := ExtractDefaultProvisionLabels(tc.instanceId, tc.details)
-
-		if !reflect.DeepEqual(labels, tc.expected) {
-			t.Errorf("Error runniung case %q, expected: %v got: %v", tn, tc.expected, labels)
-		}
-	}
 }
 
 func TestSplitNewlineDelimitedList(t *testing.T) {


### PR DESCRIPTION
Provision request details should always be JSON. We should therefore
parse them as JSON as soon as we can to validate them, as failing fast
makes it easier to trace errors. This means that storage layer should
parse when reading from the database, and parsing should also occur as
soon as possible when handling data in brokeapi.

[#181522793](https://www.pivotaltracker.com/story/show/181522793)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

