### PR TITLE
feat: beta services disabled by default

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -2,6 +2,7 @@
 
 ### Features:
 - Allow usage of non-Hashicorp providers.
+- `beta` tagged services are disabled by default. These can be enabled by supplying the environment variable: `GSB_COMPATIBILITY_ENABLE_BETA_SERVICES=true`
 
 ### Fixes:
 - If multiple versions of Terraform are specified, the nominated default version must be highest version

--- a/pkg/broker/registry.go
+++ b/pkg/broker/registry.go
@@ -31,7 +31,7 @@ var (
 		"preview":      toggles.Features.Toggle("enable-preview-services", true, `Enable services that are new to the broker this release.`),
 		"unmaintained": toggles.Features.Toggle("enable-unmaintained-services", false, `Enable broker services that are unmaintained.`),
 		"eol":          toggles.Features.Toggle("enable-eol-services", false, `Enable broker services that are end of life.`),
-		"beta":         toggles.Features.Toggle("enable-gcp-beta-services", true, "Enable services that are in GCP Beta. These have no SLA or support policy."),
+		"beta":         toggles.Features.Toggle("enable-beta-services", false, "Enable services that are tagged as Beta These have no SLA or support policy."),
 		"deprecated":   toggles.Features.Toggle("enable-gcp-deprecated-services", false, "Enable services that use deprecated GCP components."),
 		"terraform":    toggles.Features.Toggle("enable-terraform-services", false, "Enable services that use the experimental, unstable, Terraform back-end."),
 	}

--- a/pkg/broker/registry_test.go
+++ b/pkg/broker/registry_test.go
@@ -238,7 +238,7 @@ var _ = Describe("Registry", func() {
 			Entry("when preview are enabled and build-ins are enabled", "preview", "compatibility.enable-preview-services"),
 			Entry("when unmaintained are enabled and build-ins are enabled", "unmaintained", "compatibility.enable-unmaintained-services"),
 			Entry("when eol are enabled and build-ins are enabled", "eol", "compatibility.enable-eol-services"),
-			Entry("when beta are enabled and build-ins are enabled", "beta", "compatibility.enable-gcp-beta-services"),
+			Entry("when beta are enabled and build-ins are enabled", "beta", "compatibility.enable-beta-services"),
 			Entry("when deprecated are enabled and build-ins are enabled", "deprecated", "compatibility.enable-gcp-deprecated-services"),
 		)
 


### PR DESCRIPTION
This changed `beta` tagged services to be disabled by default.

[#181267511](https://www.pivotaltracker.com/story/show/181267511)

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

