### PR TITLE
chore: parse bind request details in storage layer

### DIFF
--- a/brokerapi/broker/bind.go
+++ b/brokerapi/broker/bind.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/cloudfoundry/cloud-service-broker/internal/paramparser"
+
 	"code.cloudfoundry.org/lager"
 	"github.com/cloudfoundry/cloud-service-broker/internal/storage"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/broker"
@@ -49,6 +51,11 @@ func (broker *ServiceBroker) Bind(ctx context.Context, instanceID, bindingID str
 	serviceDefinition, serviceProvider, err := broker.getDefinitionAndProvider(instanceRecord.ServiceGUID)
 	if err != nil {
 		return domain.Binding{}, fmt.Errorf("error retrieving service definition: %w", err)
+	}
+
+	parsedDetails, err := paramparser.ParseBindDetails(details)
+	if err != nil {
+		return domain.Binding{}, err
 	}
 
 	// verify the service exists and the plan exists

--- a/brokerapi/broker/bind.go
+++ b/brokerapi/broker/bind.go
@@ -6,9 +6,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/cloudfoundry/cloud-service-broker/internal/paramparser"
-
 	"code.cloudfoundry.org/lager"
+	"github.com/cloudfoundry/cloud-service-broker/internal/paramparser"
 	"github.com/cloudfoundry/cloud-service-broker/internal/storage"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/broker"
 	"github.com/cloudfoundry/cloud-service-broker/utils/correlation"
@@ -54,7 +53,7 @@ func (broker *ServiceBroker) Bind(ctx context.Context, instanceID, bindingID str
 
 	parsedDetails, err := paramparser.ParseBindDetails(details)
 	if err != nil {
-		return domain.Binding{}, err
+		return domain.Binding{}, ErrInvalidUserInput
 	}
 
 	// verify the service exists and the plan exists

--- a/brokerapi/broker/brokerfakes/fake_storage.go
+++ b/brokerapi/broker/brokerfakes/fake_storage.go
@@ -2,7 +2,6 @@
 package brokerfakes
 
 import (
-	"encoding/json"
 	"sync"
 
 	"github.com/cloudfoundry/cloud-service-broker/brokerapi/broker"
@@ -107,18 +106,18 @@ type FakeStorage struct {
 		result1 bool
 		result2 error
 	}
-	GetBindRequestDetailsStub        func(string, string) (json.RawMessage, error)
+	GetBindRequestDetailsStub        func(string, string) (storage.JSONObject, error)
 	getBindRequestDetailsMutex       sync.RWMutex
 	getBindRequestDetailsArgsForCall []struct {
 		arg1 string
 		arg2 string
 	}
 	getBindRequestDetailsReturns struct {
-		result1 json.RawMessage
+		result1 storage.JSONObject
 		result2 error
 	}
 	getBindRequestDetailsReturnsOnCall map[int]struct {
-		result1 json.RawMessage
+		result1 storage.JSONObject
 		result2 error
 	}
 	GetProvisionRequestDetailsStub        func(string) (storage.JSONObject, error)
@@ -723,7 +722,7 @@ func (fake *FakeStorage) ExistsTerraformDeploymentReturnsOnCall(i int, result1 b
 	}{result1, result2}
 }
 
-func (fake *FakeStorage) GetBindRequestDetails(arg1 string, arg2 string) (json.RawMessage, error) {
+func (fake *FakeStorage) GetBindRequestDetails(arg1 string, arg2 string) (storage.JSONObject, error) {
 	fake.getBindRequestDetailsMutex.Lock()
 	ret, specificReturn := fake.getBindRequestDetailsReturnsOnCall[len(fake.getBindRequestDetailsArgsForCall)]
 	fake.getBindRequestDetailsArgsForCall = append(fake.getBindRequestDetailsArgsForCall, struct {
@@ -749,7 +748,7 @@ func (fake *FakeStorage) GetBindRequestDetailsCallCount() int {
 	return len(fake.getBindRequestDetailsArgsForCall)
 }
 
-func (fake *FakeStorage) GetBindRequestDetailsCalls(stub func(string, string) (json.RawMessage, error)) {
+func (fake *FakeStorage) GetBindRequestDetailsCalls(stub func(string, string) (storage.JSONObject, error)) {
 	fake.getBindRequestDetailsMutex.Lock()
 	defer fake.getBindRequestDetailsMutex.Unlock()
 	fake.GetBindRequestDetailsStub = stub
@@ -762,28 +761,28 @@ func (fake *FakeStorage) GetBindRequestDetailsArgsForCall(i int) (string, string
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeStorage) GetBindRequestDetailsReturns(result1 json.RawMessage, result2 error) {
+func (fake *FakeStorage) GetBindRequestDetailsReturns(result1 storage.JSONObject, result2 error) {
 	fake.getBindRequestDetailsMutex.Lock()
 	defer fake.getBindRequestDetailsMutex.Unlock()
 	fake.GetBindRequestDetailsStub = nil
 	fake.getBindRequestDetailsReturns = struct {
-		result1 json.RawMessage
+		result1 storage.JSONObject
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeStorage) GetBindRequestDetailsReturnsOnCall(i int, result1 json.RawMessage, result2 error) {
+func (fake *FakeStorage) GetBindRequestDetailsReturnsOnCall(i int, result1 storage.JSONObject, result2 error) {
 	fake.getBindRequestDetailsMutex.Lock()
 	defer fake.getBindRequestDetailsMutex.Unlock()
 	fake.GetBindRequestDetailsStub = nil
 	if fake.getBindRequestDetailsReturnsOnCall == nil {
 		fake.getBindRequestDetailsReturnsOnCall = make(map[int]struct {
-			result1 json.RawMessage
+			result1 storage.JSONObject
 			result2 error
 		})
 	}
 	fake.getBindRequestDetailsReturnsOnCall[i] = struct {
-		result1 json.RawMessage
+		result1 storage.JSONObject
 		result2 error
 	}{result1, result2}
 }

--- a/brokerapi/broker/storage.go
+++ b/brokerapi/broker/storage.go
@@ -1,8 +1,6 @@
 package broker
 
 import (
-	"encoding/json"
-
 	"github.com/cloudfoundry/cloud-service-broker/pkg/broker"
 
 	"github.com/cloudfoundry/cloud-service-broker/internal/storage"
@@ -19,7 +17,7 @@ type Storage interface {
 	ExistsServiceBindingCredentials(bindingID, serviceInstanceID string) (bool, error)
 	DeleteServiceBindingCredentials(bindingID, serviceInstanceID string) error
 	StoreBindRequestDetails(bindRequestDetails storage.BindRequestDetails) error
-	GetBindRequestDetails(bindingID, instanceID string) (json.RawMessage, error)
+	GetBindRequestDetails(bindingID, instanceID string) (storage.JSONObject, error)
 	DeleteBindRequestDetails(bindingID, instanceID string) error
 	StoreProvisionRequestDetails(serviceInstanceID string, details storage.JSONObject) error
 	GetProvisionRequestDetails(serviceInstanceID string) (storage.JSONObject, error)

--- a/brokerapi/broker/unbind.go
+++ b/brokerapi/broker/unbind.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/cloudfoundry/cloud-service-broker/internal/paramparser"
-
 	"code.cloudfoundry.org/lager"
+	"github.com/cloudfoundry/cloud-service-broker/internal/paramparser"
 	"github.com/cloudfoundry/cloud-service-broker/utils/correlation"
 	"github.com/cloudfoundry/cloud-service-broker/utils/request"
 	"github.com/pivotal-cf/brokerapi/v8/domain"

--- a/internal/paramparser/parse_bind_details.go
+++ b/internal/paramparser/parse_bind_details.go
@@ -50,3 +50,12 @@ func ParseBindDetails(input domain.BindDetails) (BindDetails, error) {
 
 	return result, nil
 }
+
+func ParseUnbindDetails(input domain.UnbindDetails) (BindDetails, error) {
+	result := BindDetails{
+		PlanID:    input.PlanID,
+		ServiceID: input.ServiceID,
+	}
+
+	return result, nil
+}

--- a/internal/paramparser/parse_bind_details.go
+++ b/internal/paramparser/parse_bind_details.go
@@ -1,0 +1,52 @@
+package paramparser
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+)
+
+type BindDetails struct {
+	AppGUID                string
+	PlanID                 string
+	ServiceID              string
+	BindAppGuid            string
+	BindSpaceGuid          string
+	BindRoute              string
+	BindCredentialClientID string
+	BindBackupAgent        bool
+	RequestParams          map[string]interface{}
+	RequestContext         map[string]interface{}
+}
+
+func ParseBindDetails(input domain.BindDetails) (BindDetails, error) {
+	if input.BindResource == nil {
+		return BindDetails{}, fmt.Errorf("error parsing bind request details: missing bind_resource")
+	}
+
+	result := BindDetails{
+		AppGUID:                input.AppGUID,
+		PlanID:                 input.PlanID,
+		ServiceID:              input.ServiceID,
+		BindAppGuid:            input.BindResource.AppGuid,
+		BindSpaceGuid:          input.BindResource.SpaceGuid,
+		BindRoute:              input.BindResource.Route,
+		BindCredentialClientID: input.BindResource.CredentialClientID,
+		BindBackupAgent:        input.BindResource.BackupAgent,
+	}
+
+	if len(input.RawParameters) > 0 {
+		if err := json.Unmarshal(input.RawParameters, &result.RequestParams); err != nil {
+			return BindDetails{}, fmt.Errorf("error parsing request parameters: %w", err)
+		}
+	}
+
+	if len(input.RawContext) > 0 {
+		if err := json.Unmarshal(input.RawContext, &result.RequestContext); err != nil {
+			return BindDetails{}, fmt.Errorf("error parsing request context: %w", err)
+		}
+	}
+
+	return result, nil
+}

--- a/internal/paramparser/parse_bind_details.go
+++ b/internal/paramparser/parse_bind_details.go
@@ -8,32 +8,23 @@ import (
 )
 
 type BindDetails struct {
-	AppGUID                string
-	PlanID                 string
-	ServiceID              string
-	BindAppGuid            string
-	BindSpaceGuid          string
-	BindRoute              string
-	BindCredentialClientID string
-	BindBackupAgent        bool
-	RequestParams          map[string]interface{}
-	RequestContext         map[string]interface{}
+	AppGUID        string
+	PlanID         string
+	ServiceID      string
+	BindAppGUID    string
+	RequestParams  map[string]interface{}
+	RequestContext map[string]interface{}
 }
 
 func ParseBindDetails(input domain.BindDetails) (BindDetails, error) {
-	if input.BindResource == nil {
-		return BindDetails{}, fmt.Errorf("error parsing bind request details: missing bind_resource")
+	result := BindDetails{
+		AppGUID:   input.AppGUID,
+		PlanID:    input.PlanID,
+		ServiceID: input.ServiceID,
 	}
 
-	result := BindDetails{
-		AppGUID:                input.AppGUID,
-		PlanID:                 input.PlanID,
-		ServiceID:              input.ServiceID,
-		BindAppGuid:            input.BindResource.AppGuid,
-		BindSpaceGuid:          input.BindResource.SpaceGuid,
-		BindRoute:              input.BindResource.Route,
-		BindCredentialClientID: input.BindResource.CredentialClientID,
-		BindBackupAgent:        input.BindResource.BackupAgent,
+	if input.BindResource != nil {
+		result.BindAppGUID = input.BindResource.AppGuid
 	}
 
 	if len(input.RawParameters) > 0 {

--- a/internal/paramparser/parse_bind_details.go
+++ b/internal/paramparser/parse_bind_details.go
@@ -41,12 +41,3 @@ func ParseBindDetails(input domain.BindDetails) (BindDetails, error) {
 
 	return result, nil
 }
-
-func ParseUnbindDetails(input domain.UnbindDetails) (BindDetails, error) {
-	result := BindDetails{
-		PlanID:    input.PlanID,
-		ServiceID: input.ServiceID,
-	}
-
-	return result, nil
-}

--- a/internal/paramparser/parse_bind_details_test.go
+++ b/internal/paramparser/parse_bind_details_test.go
@@ -41,16 +41,6 @@ var _ = Describe("ParseBindDetails", func() {
 		}))
 	})
 
-	When("params are not valid JSON", func() {
-		It("returns an error", func() {
-			bindDetails, err := paramparser.ParseBindDetails(domain.BindDetails{BindResource: &domain.BindResource{}, RawParameters: []byte("not-json")})
-
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(`error parsing request parameters: invalid character 'o' in literal null (expecting 'u')`))
-			Expect(bindDetails).To(BeZero())
-		})
-	})
-
 	When("no bind_resource is instantiated", func() {
 		It("returns an error", func() {
 			bindDetails, err := paramparser.ParseBindDetails(domain.BindDetails{})
@@ -63,13 +53,30 @@ var _ = Describe("ParseBindDetails", func() {
 
 	When("context is not valid JSON", func() {
 		It("returns an error", func() {
+			bindDetails, err := paramparser.ParseBindDetails(domain.BindDetails{BindResource: &domain.BindResource{}, RawContext: []byte("not-json")})
 
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(`error parsing request context: invalid character 'o' in literal null (expecting 'u')`))
+			Expect(bindDetails).To(BeZero())
+		})
+	})
+
+	When("params are not valid JSON", func() {
+		It("returns an error", func() {
+			bindDetails, err := paramparser.ParseBindDetails(domain.BindDetails{BindResource: &domain.BindResource{}, RawParameters: []byte("not-json")})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(`error parsing request parameters: invalid character 'o' in literal null (expecting 'u')`))
+			Expect(bindDetails).To(BeZero())
 		})
 	})
 
 	When("input is empty", func() {
 		It("succeeds with an empty result", func() {
+			bindDetails, err := paramparser.ParseBindDetails(domain.BindDetails{BindResource: &domain.BindResource{}})
 
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bindDetails).To(BeZero())
 		})
 	})
 })

--- a/internal/paramparser/parse_bind_details_test.go
+++ b/internal/paramparser/parse_bind_details_test.go
@@ -1,0 +1,75 @@
+package paramparser_test
+
+import (
+	"github.com/cloudfoundry/cloud-service-broker/internal/paramparser"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+)
+
+var _ = Describe("ParseBindDetails", func() {
+	It("can parse bind details", func() {
+		fakeDomainBindDetails := domain.BindDetails{
+			AppGUID:   "fake-app-guid",
+			PlanID:    "fake-plan-id",
+			ServiceID: "fake-service-id",
+			BindResource: &domain.BindResource{
+				AppGuid:            "fake-bind-app-guid",
+				SpaceGuid:          "fake-bind-space-guid",
+				Route:              "fake-bind-route",
+				CredentialClientID: "fake-bind-credential-client-id",
+				BackupAgent:        false,
+			},
+			RawContext:    []byte(`{"foo": "bar"}`),
+			RawParameters: []byte(`{"baz": "quz"}`),
+		}
+
+		bindDetails, err := paramparser.ParseBindDetails(fakeDomainBindDetails)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bindDetails).To(Equal(paramparser.BindDetails{
+			AppGUID:                fakeDomainBindDetails.AppGUID,
+			PlanID:                 fakeDomainBindDetails.PlanID,
+			ServiceID:              fakeDomainBindDetails.ServiceID,
+			BindAppGuid:            fakeDomainBindDetails.BindResource.AppGuid,
+			BindSpaceGuid:          fakeDomainBindDetails.BindResource.SpaceGuid,
+			BindRoute:              fakeDomainBindDetails.BindResource.Route,
+			BindCredentialClientID: fakeDomainBindDetails.BindResource.CredentialClientID,
+			BindBackupAgent:        false,
+			RequestParams:          map[string]interface{}{"baz": "quz"},
+			RequestContext:         map[string]interface{}{"foo": "bar"},
+		}))
+	})
+
+	When("params are not valid JSON", func() {
+		It("returns an error", func() {
+			bindDetails, err := paramparser.ParseBindDetails(domain.BindDetails{BindResource: &domain.BindResource{}, RawParameters: []byte("not-json")})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(`error parsing request parameters: invalid character 'o' in literal null (expecting 'u')`))
+			Expect(bindDetails).To(BeZero())
+		})
+	})
+
+	When("no bind_resource is instantiated", func() {
+		It("returns an error", func() {
+			bindDetails, err := paramparser.ParseBindDetails(domain.BindDetails{})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(`error parsing bind request details: missing bind_resource`))
+			Expect(bindDetails).To(BeZero())
+		})
+	})
+
+	When("context is not valid JSON", func() {
+		It("returns an error", func() {
+
+		})
+	})
+
+	When("input is empty", func() {
+		It("succeeds with an empty result", func() {
+
+		})
+	})
+})

--- a/internal/paramparser/parse_bind_details_test.go
+++ b/internal/paramparser/parse_bind_details_test.go
@@ -14,11 +14,7 @@ var _ = Describe("ParseBindDetails", func() {
 			PlanID:    "fake-plan-id",
 			ServiceID: "fake-service-id",
 			BindResource: &domain.BindResource{
-				AppGuid:            "fake-bind-app-guid",
-				SpaceGuid:          "fake-bind-space-guid",
-				Route:              "fake-bind-route",
-				CredentialClientID: "fake-bind-credential-client-id",
-				BackupAgent:        false,
+				AppGuid: "fake-bind-app-guid",
 			},
 			RawContext:    []byte(`{"foo": "bar"}`),
 			RawParameters: []byte(`{"baz": "quz"}`),
@@ -28,26 +24,29 @@ var _ = Describe("ParseBindDetails", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(bindDetails).To(Equal(paramparser.BindDetails{
-			AppGUID:                fakeDomainBindDetails.AppGUID,
-			PlanID:                 fakeDomainBindDetails.PlanID,
-			ServiceID:              fakeDomainBindDetails.ServiceID,
-			BindAppGuid:            fakeDomainBindDetails.BindResource.AppGuid,
-			BindSpaceGuid:          fakeDomainBindDetails.BindResource.SpaceGuid,
-			BindRoute:              fakeDomainBindDetails.BindResource.Route,
-			BindCredentialClientID: fakeDomainBindDetails.BindResource.CredentialClientID,
-			BindBackupAgent:        false,
-			RequestParams:          map[string]interface{}{"baz": "quz"},
-			RequestContext:         map[string]interface{}{"foo": "bar"},
+			AppGUID:        "fake-app-guid",
+			PlanID:         "fake-plan-id",
+			ServiceID:      "fake-service-id",
+			BindAppGUID:    "fake-bind-app-guid",
+			RequestParams:  map[string]interface{}{"baz": "quz"},
+			RequestContext: map[string]interface{}{"foo": "bar"},
 		}))
 	})
 
 	When("no bind_resource is instantiated", func() {
-		It("returns an error", func() {
-			bindDetails, err := paramparser.ParseBindDetails(domain.BindDetails{})
+		It("succeeds", func() {
+			bindDetails, err := paramparser.ParseBindDetails(domain.BindDetails{
+				AppGUID:   "fake-app-guid",
+				PlanID:    "fake-plan-id",
+				ServiceID: "fake-service-id",
+			})
 
-			Expect(err).To(HaveOccurred())
-			Expect(err).To(MatchError(`error parsing bind request details: missing bind_resource`))
-			Expect(bindDetails).To(BeZero())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(bindDetails).To(Equal(paramparser.BindDetails{
+				AppGUID:   "fake-app-guid",
+				PlanID:    "fake-plan-id",
+				ServiceID: "fake-service-id",
+			}))
 		})
 	})
 
@@ -55,7 +54,6 @@ var _ = Describe("ParseBindDetails", func() {
 		It("returns an error", func() {
 			bindDetails, err := paramparser.ParseBindDetails(domain.BindDetails{BindResource: &domain.BindResource{}, RawContext: []byte("not-json")})
 
-			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(`error parsing request context: invalid character 'o' in literal null (expecting 'u')`))
 			Expect(bindDetails).To(BeZero())
 		})
@@ -65,7 +63,6 @@ var _ = Describe("ParseBindDetails", func() {
 		It("returns an error", func() {
 			bindDetails, err := paramparser.ParseBindDetails(domain.BindDetails{BindResource: &domain.BindResource{}, RawParameters: []byte("not-json")})
 
-			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(`error parsing request parameters: invalid character 'o' in literal null (expecting 'u')`))
 			Expect(bindDetails).To(BeZero())
 		})

--- a/internal/paramparser/parse_update_details_test.go
+++ b/internal/paramparser/parse_update_details_test.go
@@ -37,7 +37,7 @@ var _ = Describe("ParseUpdateDetails", func() {
 
 	When("params are not valid JSON", func() {
 		It("returns an error", func() {
-			ud, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{
+			ud, err := paramparser.ParseUpdateDetails(domain.UpdateDetails{
 				RawParameters: []byte(`not-json`),
 			})
 
@@ -48,7 +48,7 @@ var _ = Describe("ParseUpdateDetails", func() {
 
 	When("context is not valid JSON", func() {
 		It("returns an error", func() {
-			ud, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{
+			ud, err := paramparser.ParseUpdateDetails(domain.UpdateDetails{
 				RawContext: []byte(`not-json`),
 			})
 
@@ -59,7 +59,7 @@ var _ = Describe("ParseUpdateDetails", func() {
 
 	When("input is empty", func() {
 		It("succeeds with an empty result", func() {
-			ud, err := paramparser.ParseProvisionDetails(domain.ProvisionDetails{})
+			ud, err := paramparser.ParseUpdateDetails(domain.UpdateDetails{})
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ud).To(BeZero())

--- a/internal/storage/bind_request_details.go
+++ b/internal/storage/bind_request_details.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/cloudfoundry/cloud-service-broker/db_service/models"
@@ -10,7 +9,7 @@ import (
 type BindRequestDetails struct {
 	ServiceInstanceGUID string
 	ServiceBindingGUID  string
-	RequestDetails      []byte
+	RequestDetails      JSONObject
 }
 
 func (s *Storage) StoreBindRequestDetails(bindRequestDetails BindRequestDetails) error {
@@ -18,7 +17,7 @@ func (s *Storage) StoreBindRequestDetails(bindRequestDetails BindRequestDetails)
 		return nil
 	}
 
-	encoded, err := s.encodeBytes(bindRequestDetails.RequestDetails)
+	encoded, err := s.encodeJSON(bindRequestDetails.RequestDetails)
 	if err != nil {
 		return fmt.Errorf("error encoding details: %w", err)
 	}
@@ -44,7 +43,7 @@ func (s *Storage) StoreBindRequestDetails(bindRequestDetails BindRequestDetails)
 	return nil
 }
 
-func (s *Storage) GetBindRequestDetails(bindingID string, instanceID string) (json.RawMessage, error) {
+func (s *Storage) GetBindRequestDetails(bindingID string, instanceID string) (JSONObject, error) {
 	exists, err := s.existsBindRequestDetails(bindingID, instanceID)
 	switch {
 	case err != nil:
@@ -58,7 +57,7 @@ func (s *Storage) GetBindRequestDetails(bindingID string, instanceID string) (js
 		return nil, fmt.Errorf("error finding bind request details record: %w", err)
 	}
 
-	decoded, err := s.decodeBytes(receiver.RequestDetails)
+	decoded, err := s.decodeJSONObject(receiver.RequestDetails)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding bind request details %q: %w", bindingID, err)
 	}

--- a/internal/storage/bind_request_details_test.go
+++ b/internal/storage/bind_request_details_test.go
@@ -1,7 +1,6 @@
 package storage_test
 
 import (
-	"encoding/json"
 	"errors"
 
 	"github.com/cloudfoundry/cloud-service-broker/internal/storage"
@@ -20,7 +19,7 @@ var _ = Describe("BindRequestDetails", func() {
 			err := store.StoreBindRequestDetails(storage.BindRequestDetails{
 				ServiceInstanceGUID: serviceInstanceId,
 				ServiceBindingGUID:  serviceBindingId,
-				RequestDetails:      json.RawMessage(`{"foo":"bar"}`),
+				RequestDetails:      storage.JSONObject{"foo": "bar"},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -50,7 +49,7 @@ var _ = Describe("BindRequestDetails", func() {
 				err := store.StoreBindRequestDetails(storage.BindRequestDetails{
 					ServiceInstanceGUID: serviceInstanceId,
 					ServiceBindingGUID:  serviceBindingId,
-					RequestDetails:      json.RawMessage(`{"foo":"bar"}`),
+					RequestDetails:      storage.JSONObject{"foo": "bar"},
 				})
 				Expect(err).To(MatchError("error encoding details: encryption error: bang"))
 			})
@@ -68,7 +67,7 @@ var _ = Describe("BindRequestDetails", func() {
 				err := store.StoreBindRequestDetails(storage.BindRequestDetails{
 					ServiceInstanceGUID: serviceInstanceId,
 					ServiceBindingGUID:  serviceBindingId,
-					RequestDetails:      json.RawMessage(`{"foo":"qux"}`),
+					RequestDetails:      storage.JSONObject{"foo": "qux"},
 				})
 				Expect(err).To(MatchError(ContainSubstring("error saving bind request details: Binding already exists")))
 			})
@@ -83,7 +82,7 @@ var _ = Describe("BindRequestDetails", func() {
 		It("reads the right object from the database", func() {
 			r, err := store.GetBindRequestDetails("fake-binding-id", "fake-instance-id")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(r).To(Equal(json.RawMessage(`{"decrypted":{"foo":"bar"}}`)))
+			Expect(r).To(Equal(storage.JSONObject{"decrypted": map[string]interface{}{"foo": "bar"}}))
 		})
 
 		When("decoding fails", func() {

--- a/internal/storage/check_all_records.go
+++ b/internal/storage/check_all_records.go
@@ -51,7 +51,7 @@ func (s *Storage) checkAllBindRequestDetails() (errs *multierror.Error) {
 	var bindRequestDetailsBatch []models.BindRequestDetails
 	result := s.db.FindInBatches(&bindRequestDetailsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
 		for i := range bindRequestDetailsBatch {
-			_, err := s.decodeBytes(bindRequestDetailsBatch[i].RequestDetails)
+			_, err := s.decodeJSONObject(bindRequestDetailsBatch[i].RequestDetails)
 			if err != nil {
 				errs = multierror.Append(fmt.Errorf("decode error for binding request details %q: %w", bindRequestDetailsBatch[i].ServiceBindingId, err), errs)
 			}

--- a/internal/storage/check_all_records_test.go
+++ b/internal/storage/check_all_records_test.go
@@ -48,7 +48,13 @@ var _ = Describe("CheckAllRecords", func() {
 
 			Expect(db.Create(&models.BindRequestDetails{
 				RequestDetails:    []byte(`cannot-be-decrypted`),
-				ServiceBindingId:  "fake-bad-binding-id",
+				ServiceBindingId:  "fake-bad-binding-id-1",
+				ServiceInstanceId: "fake-bad-instance-id",
+			}).Error).NotTo(HaveOccurred())
+
+			Expect(db.Create(&models.BindRequestDetails{
+				RequestDetails:    []byte(`request-details-not-json`),
+				ServiceBindingId:  "fake-bad-binding-id-2",
 				ServiceInstanceId: "fake-bad-instance-id",
 			}).Error).NotTo(HaveOccurred())
 
@@ -77,7 +83,8 @@ var _ = Describe("CheckAllRecords", func() {
 				ContainSubstring(`decode error for service binding credential "fake-bad-binding-id-2": decryption error: fake decryption error`),
 				ContainSubstring(`decode error for provision request details "fake-bad-instance-id-1": decryption error: fake decryption error`),
 				ContainSubstring(`decode error for provision request details "fake-bad-instance-id-2": JSON parse error: invalid character 'r' looking for beginning of value`),
-				ContainSubstring(`decode error for binding request details "fake-bad-binding-id": decryption error: fake decryption error`),
+				ContainSubstring(`decode error for binding request details "fake-bad-binding-id-1": decryption error: fake decryption error`),
+				ContainSubstring(`decode error for binding request details "fake-bad-binding-id-2": JSON parse error: invalid character 'r' looking for beginning of value`),
 				ContainSubstring(`decode error for service instance details "fake-bad-instance-id-1": JSON parse error: invalid character 's' looking for beginning of value`),
 				ContainSubstring(`decode error for service instance details "fake-bad-instance-id-2": decryption error: fake decryption error`),
 				ContainSubstring(`decode error for terraform deployment "fake-bad-id": decryption error: fake decryption error`),

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -1013,10 +1013,11 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 			defer viper.Reset()
 
 			details := domain.BindDetails{RawParameters: json.RawMessage(tc.UserParams), RawContext: json.RawMessage(tc.RawContext)}
+			parsedDetails, _ := paramparser.ParseBindDetails(details)
 			instance := storage.ServiceInstanceDetails{Outputs: tc.InstanceVars}
 
 			service.Plans[0].BindOverrides = tc.BindOverrides
-			vars, err := service.BindVariables(instance, "binding-id-here", details, &service.Plans[0], tc.OriginatingIdentity)
+			vars, err := service.BindVariables(instance, "binding-id-here", parsedDetails, &service.Plans[0], tc.OriginatingIdentity)
 
 			expectError(t, tc.ExpectedError, err)
 

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -452,11 +452,6 @@ func (svc *ServiceDefinition) UpdateVariables(instanceId string, details parampa
 // 5. Default variables (in `bind_input_variables`).
 //
 func (svc *ServiceDefinition) BindVariables(instance storage.ServiceInstanceDetails, bindingID string, details paramparser.BindDetails, plan *ServicePlan, originatingIdentity map[string]interface{}) (*varcontext.VarContext, error) {
-	var appGuid string
-	if details.BindAppGuid != "" {
-		appGuid = details.BindAppGuid
-	}
-
 	// The namespaces of these values roughly align with the OSB spec.
 	constants := map[string]interface{}{
 		"request.x_broker_api_originating_identity": originatingIdentity,
@@ -472,7 +467,7 @@ func (svc *ServiceDefinition) BindVariables(instance storage.ServiceInstanceDeta
 		// the duplicate sending of fields is likely to be removed.
 		"request.plan_id":         instance.PlanGUID,
 		"request.service_id":      instance.ServiceGUID,
-		"request.app_guid":        appGuid,
+		"request.app_guid":        details.BindAppGUID,
 		"request.plan_properties": plan.GetServiceProperties(),
 
 		// specified by the existing instance


### PR DESCRIPTION
Bind request details should always be JSON. We should therefore
parse them as JSON as soon as we can to validate them, as failing fast
makes it easier to trace errors. This means that storage layer should
parse when reading from the database, and parsing should also occur as
soon as possible when handling data in brokeapi.

[#181522793](https://www.pivotaltracker.com/story/show/181522793)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

