### PR TITLE
chore: clean up TF version parsing

### DIFF
--- a/pkg/providers/tf/workspace/workspace.go
+++ b/pkg/providers/tf/workspace/workspace.go
@@ -112,17 +112,14 @@ type TerraformWorkspace struct {
 	dir     string
 }
 
-type tfState struct {
-	Version string `json:"terraform_version"`
-}
-
 func (workspace *TerraformWorkspace) StateVersion() (*version.Version, error) {
-	tf := tfState{}
-	err := json.Unmarshal(workspace.State, &tf)
-	if err != nil {
+	var receiver struct {
+		Version string `json:"terraform_version"`
+	}
+	if err := json.Unmarshal(workspace.State, &receiver); err != nil {
 		return nil, err
 	}
-	return version.NewVersion(tf.Version)
+	return version.NewVersion(receiver.Version)
 }
 
 func (workspace *TerraformWorkspace) HasState() bool {


### PR DESCRIPTION
The struct for parsing the version doesn't need package scope

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

