### PR TITLE
chore: check terraform workspace parse in storage layer

### DIFF
--- a/internal/storage/check_all_records.go
+++ b/internal/storage/check_all_records.go
@@ -108,7 +108,7 @@ func (s *Storage) checkAllTerraformDeployments() (errs *multierror.Error) {
 	var terraformDeploymentBatch []models.TerraformDeployment
 	result := s.db.FindInBatches(&terraformDeploymentBatch, 100, func(tx *gorm.DB, batchNumber int) error {
 		for i := range terraformDeploymentBatch {
-			_, err := s.decodeBytes(terraformDeploymentBatch[i].Workspace)
+			_, err := s.decodeJSONObject(terraformDeploymentBatch[i].Workspace)
 			if err != nil {
 				errs = multierror.Append(fmt.Errorf("decode error for terraform deployment %q: %w", terraformDeploymentBatch[i].ID, err), errs)
 			}

--- a/internal/storage/check_all_records_test.go
+++ b/internal/storage/check_all_records_test.go
@@ -69,8 +69,16 @@ var _ = Describe("CheckAllRecords", func() {
 			}).Error).NotTo(HaveOccurred())
 
 			Expect(db.Create(&models.TerraformDeployment{
-				ID:                   "fake-bad-id",
+				ID:                   "fake-bad-id-1",
 				Workspace:            []byte("cannot-be-decrypted"),
+				LastOperationType:    "create",
+				LastOperationState:   "succeeded",
+				LastOperationMessage: "amazing",
+			}).Error).NotTo(HaveOccurred())
+
+			Expect(db.Create(&models.TerraformDeployment{
+				ID:                   "fake-bad-id-2",
+				Workspace:            []byte("workspace-not-json"),
 				LastOperationType:    "create",
 				LastOperationState:   "succeeded",
 				LastOperationMessage: "amazing",
@@ -87,7 +95,8 @@ var _ = Describe("CheckAllRecords", func() {
 				ContainSubstring(`decode error for binding request details "fake-bad-binding-id-2": JSON parse error: invalid character 'r' looking for beginning of value`),
 				ContainSubstring(`decode error for service instance details "fake-bad-instance-id-1": JSON parse error: invalid character 's' looking for beginning of value`),
 				ContainSubstring(`decode error for service instance details "fake-bad-instance-id-2": decryption error: fake decryption error`),
-				ContainSubstring(`decode error for terraform deployment "fake-bad-id": decryption error: fake decryption error`),
+				ContainSubstring(`decode error for terraform deployment "fake-bad-id-1": decryption error: fake decryption error`),
+				ContainSubstring(`decode error for terraform deployment "fake-bad-id-2": JSON parse error: invalid character 'w' looking for beginning of value`),
 			)))
 		})
 	})

--- a/internal/storage/terraform_deployments_test.go
+++ b/internal/storage/terraform_deployments_test.go
@@ -76,7 +76,7 @@ var _ = Describe("TerraformDeployments", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(r.ID).To(Equal("fake-id-2"))
-			Expect(r.Workspace).To(Equal([]byte(`{"decrypted":fake-workspace-2}`)))
+			Expect(r.Workspace).To(Equal([]byte(`{"decrypted":{"workspace":"fake-2"}}`)))
 			Expect(r.LastOperationType).To(Equal("update"))
 			Expect(r.LastOperationState).To(Equal("failed"))
 			Expect(r.LastOperationMessage).To(Equal("too bad"))
@@ -135,21 +135,21 @@ var _ = Describe("TerraformDeployments", func() {
 func addFakeTerraformDeployments() {
 	Expect(db.Create(&models.TerraformDeployment{
 		ID:                   "fake-id-1",
-		Workspace:            []byte("fake-workspace-1"),
+		Workspace:            []byte(`{"workspace":"fake-1"}`),
 		LastOperationType:    "create",
 		LastOperationState:   "succeeded",
 		LastOperationMessage: "amazing",
 	}).Error).NotTo(HaveOccurred())
 	Expect(db.Create(&models.TerraformDeployment{
 		ID:                   "fake-id-2",
-		Workspace:            []byte("fake-workspace-2"),
+		Workspace:            []byte(`{"workspace":"fake-2"}`),
 		LastOperationType:    "update",
 		LastOperationState:   "failed",
 		LastOperationMessage: "too bad",
 	}).Error).NotTo(HaveOccurred())
 	Expect(db.Create(&models.TerraformDeployment{
 		ID:                   "fake-id-3",
-		Workspace:            []byte("fake-workspace-3"),
+		Workspace:            []byte(`{"workspace":"fake-3"}`),
 		LastOperationType:    "update",
 		LastOperationState:   "succeeded",
 		LastOperationMessage: "great",

--- a/internal/storage/update_all_records_test.go
+++ b/internal/storage/update_all_records_test.go
@@ -59,9 +59,9 @@ var _ = Describe("UpdateAllRecords", func() {
 			var receiver []models.TerraformDeployment
 			Expect(db.Find(&receiver).Error).NotTo(HaveOccurred())
 			Expect(receiver).To(HaveLen(3))
-			Expect(receiver[0].Workspace).To(Equal([]byte(`{"encrypted":{"decrypted":fake-workspace-1}}`)))
-			Expect(receiver[1].Workspace).To(Equal([]byte(`{"encrypted":{"decrypted":fake-workspace-2}}`)))
-			Expect(receiver[2].Workspace).To(Equal([]byte(`{"encrypted":{"decrypted":fake-workspace-3}}`)))
+			Expect(receiver[0].Workspace).To(Equal([]byte(`{"encrypted":{"decrypted":{"workspace":"fake-1"}}}`)))
+			Expect(receiver[1].Workspace).To(Equal([]byte(`{"encrypted":{"decrypted":{"workspace":"fake-2"}}}`)))
+			Expect(receiver[2].Workspace).To(Equal([]byte(`{"encrypted":{"decrypted":{"workspace":"fake-3"}}}`)))
 		})
 	})
 


### PR DESCRIPTION
This checks that the Terraform workspace can be parsed from JSON.

At the moment, the workspace is parsed again into a struct{} later. There
is a potential further refactor where the workspace is not parsed again,
but it's much more complex than doing this change, and we hope to make
that improvement later.

[#181522793](https://www.pivotaltracker.com/story/show/181522793)

### Checklist:

* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

