### PR TITLE
Add additional provision/bind override scopes

### DIFF
--- a/docs/brokerpak-specification.md
+++ b/docs/brokerpak-specification.md
@@ -462,7 +462,7 @@ The broker makes additional variables available to be used during provision and 
 
 The order of combining all plan properties before invoking Terraform is as follows:
 1. Operator default variables loaded from the environment.
-   * `GSB_PROVISION_DEFAULTS` values first and then `GSB_SERVICE_*SERVICE_NAME*_PROVISION_DEFAULTS`. 
+   * `GSB_PROVISION_DEFAULTS` values first and then `GSB_*SCOPE*_*SCOPE_ID*_PROVISION_DEFAULTS`.  Scope can be "SERVICE","ORG","SPACE" or "NAMESPACE" and the corresponding IDs are the service name, organization GUID, space GUID and the name of the namespace.
 1. User defined variables provided during provision/bind call.
    * The variable constraints are defined in `service_definitions.provision.user_inputs` or `service_definitions.bind.user_inputs` 
    * These values overwrite the above values if set.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,6 +140,9 @@ Brokerpak configuration values:
 |<tt>GSB_BROKERPAK_CONFIG</tt>|brokerpak.config| string | JSON global config for broker pak services|
 |<tt>GSB_PROVISION_DEFAULTS</tt>|provision.defaults| string | JSON global provision defaults|
 |<tt>GSB_SERVICE_*SERVICE_NAME*_PROVISION_DEFAULTS</tt>|service.*service-name*.provision.defaults| string | JSON provision defaults override for *service-name*|
+|<tt>GSB_ORG_*ORG_GUID*_PROVISION_DEFAULTS</tt>|org.*org-guid*.provision.defaults| string | JSON provision defaults override for *org-guid*|
+|<tt>GSB_SPACE_*SPACE_GUID*_PROVISION_DEFAULTS</tt>|space.*space-guid*.provision.defaults| string | JSON provision defaults override for *space-guid*|
+|<tt>GSB_NAMESPACE_*NAMESPACE*_PROVISION_DEFAULTS</tt>|namespace.*namespace*.provision.defaults| string | JSON provision defaults override for *namespace*|
 |<tt>GSB_SERVICE_*SERVICE_NAME*_PLANS</tt>|service.*service-name*.plans| string | JSON plan collection to augment plans for *service-name*|
 
 

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -2,6 +2,7 @@
 
 ### Features:
 - Allow usage of non-Hashicorp providers.
+- Add additional provision/bind default override scopes (org GUID, space GUID and k8s namespace).
 
 ### Fixes:
 - If multiple versions of Terraform are specified, the nominated default version must be highest version
@@ -9,4 +10,3 @@
 - Error messages during encryption tell you how to fix the issue
 - Error messages during encryption log DB row ID
 - Checks the database for readability of all fields before attempting encryption or removing salt
-

--- a/pkg/broker/broker_test.go
+++ b/pkg/broker/broker_test.go
@@ -511,7 +511,7 @@ func TestServiceDefinition_ProvisionVariables(t *testing.T) {
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
 			if len(tc.DefaultOverride) > 0 {
-				viper.Set(service.ProvisionDefaultOverrideProperty(), tc.DefaultOverride)
+				viper.Set(ProvisionDefaultOverrideProperty(SERVICE_SCOPE, service.Name), tc.DefaultOverride)
 			}
 			if len(tc.GlobalDefaults) > 0 {
 				viper.Set(GlobalProvisionDefaults, tc.GlobalDefaults)
@@ -779,7 +779,7 @@ func TestServiceDefinition_UpdateVariables(t *testing.T) {
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
 			if len(tc.DefaultOverride) > 0 {
-				viper.Set(service.ProvisionDefaultOverrideProperty(), tc.DefaultOverride)
+				viper.Set(ProvisionDefaultOverrideProperty(SERVICE_SCOPE, service.Name), tc.DefaultOverride)
 			}
 			if len(tc.GlobalDefaults) > 0 {
 				viper.Set(GlobalProvisionDefaults, tc.GlobalDefaults)
@@ -1004,7 +1004,7 @@ func TestServiceDefinition_BindVariables(t *testing.T) {
 
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
-			viper.Set(service.BindDefaultOverrideProperty(), tc.DefaultOverride)
+			viper.Set(BindDefaultOverrideProperty(SERVICE_SCOPE, service.Name), tc.DefaultOverride)
 			defer viper.Reset()
 
 			details := domain.BindDetails{RawParameters: json.RawMessage(tc.UserParams), RawContext: json.RawMessage(tc.RawContext)}


### PR DESCRIPTION
Most services provided by the service broker are either bound to a default project or have to be targeted against a specific project on creation-time using provision parameters.

This can lead to some architectural challenges (depending on the cloud provider you're using).
Since we're using GCP, I can provide some insights on the limitations of the above mechanism:

1. There are quotas and limits for services in GCP (e.g. a maximum amount of ~100 CloudSQL instances). Some of them are configurable, some of them are not.
Assuming that developers want to be able to "easily provision a service" without having to provide that many provision parameters such as a GCP project, many of the services will be deployed to the same shared default project. 
<br>This caused some issues for us in the past, since we used the (old) gcp-service-broker and ran into some limitations in the default project and had to modify the service broker to be able to provision services to separate projects.

2. It's hard or nearly impossible to grant service permissions to developer teams when all services are provisioned to a shared default project (at least on GCP).

This PR adds additional configuration flags to override the default provision and bind parameters so that operators can predefine the projects that should be targeted for the service creation based on more specific values than the service name.

E.g.:
By providing environment variables such as `GSB_ORG_<ORG_GUID>_PROVISION_DEFAULTS: {"project":"my-<ORG_GUID>-specific-project"}`, the project variable can be predefined for a specific org GUID.

I added 3 new scopes for the default overrides. Both for provision and bind parameters:
- org (`GSB_ORG_<ORG_GUID>_PROVISION_DEFAULTS` | `GSB_ORG_<ORG_GUID>_BIND_DEFAULTS`)
- space (`GSB_SPACE_<SPACE_GUID>_PROVISION_DEFAULTS` | `GSB_SPACE_<SPACE_GUID>_BIND_DEFAULTS`)
- (k8s) namespace (`GSB_NAMESPACE_<NAMESPACE>_PROVISION_DEFAULTS` | `GSB_NAMESPACE_<NAMESPACE>_BIND_DEFAULTS`)

I used the Context Object mentioned in the [Open Service Broker Specification](https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#context-object) to gather the GUID/Namespace values.

### Checklist:

* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

