### PR TITLE
chore: improve testing of JSON parsing from database

### DIFF
--- a/internal/storage/bind_request_details_test.go
+++ b/internal/storage/bind_request_details_test.go
@@ -107,6 +107,20 @@ var _ = Describe("BindRequestDetails", func() {
 				Expect(details).To(BeNil())
 			})
 		})
+
+		DescribeTable(
+			"JSON parsing",
+			func(input []byte) {
+				encryptor.DecryptReturns(input, nil)
+
+				r, err := store.GetBindRequestDetails("fake-binding-id", "fake-instance-id")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(r).To(Equal(storage.JSONObject(nil)))
+			},
+			Entry("null", []byte(`null`)),
+			Entry("empty", []byte(``)),
+			Entry("nil", []byte(nil)),
+		)
 	})
 
 	Describe("DeleteBindRequestDetails", func() {

--- a/internal/storage/provision_request_details_test.go
+++ b/internal/storage/provision_request_details_test.go
@@ -86,6 +86,20 @@ var _ = Describe("ProvisionRequestDetails", func() {
 				Expect(err).To(MatchError("could not find provision request details for service instance: not-there"))
 			})
 		})
+
+		DescribeTable(
+			"JSON parsing",
+			func(input []byte) {
+				encryptor.DecryptReturns(input, nil)
+
+				r, err := store.GetProvisionRequestDetails("fake-instance-id")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(r).To(Equal(storage.JSONObject(nil)))
+			},
+			Entry("null", []byte(`null`)),
+			Entry("empty", []byte(``)),
+			Entry("nil", []byte(nil)),
+		)
 	})
 
 	Describe("DeleteProvisionRequestDetails", func() {

--- a/internal/storage/service_binding_credentials_test.go
+++ b/internal/storage/service_binding_credentials_test.go
@@ -81,16 +81,19 @@ var _ = Describe("ServiceBindingCredentials", func() {
 			})
 		})
 
-		When("OtherDetails field is empty", func() {
-			It("succeeds with an empty result", func() {
-				encryptor.DecryptReturns([]byte(""), nil)
+		DescribeTable(
+			"JSON parsing",
+			func(input []byte) {
+				encryptor.DecryptReturns(input, nil)
 
 				r, err := store.GetServiceBindingCredentials("fake-binding-id", "fake-instance-id")
 				Expect(err).NotTo(HaveOccurred())
-
-				Expect(r.Credentials).To(BeEmpty())
-			})
-		})
+				Expect(r.Credentials).To(Equal(storage.JSONObject(nil)))
+			},
+			Entry("null", []byte(`null`)),
+			Entry("empty", []byte(``)),
+			Entry("nil", []byte(nil)),
+		)
 	})
 
 	Describe("ExistsServiceBindingCredentials", func() {

--- a/internal/storage/service_instance_details_test.go
+++ b/internal/storage/service_instance_details_test.go
@@ -126,16 +126,19 @@ var _ = Describe("ServiceInstanceDetails", func() {
 			})
 		})
 
-		When("OtherDetails field is empty", func() {
-			It("succeeds with an empty result", func() {
-				encryptor.DecryptReturns([]byte(""), nil)
+		DescribeTable(
+			"JSON parsing",
+			func(input []byte) {
+				encryptor.DecryptReturns(input, nil)
 
 				r, err := store.GetServiceInstanceDetails("fake-id-1")
 				Expect(err).NotTo(HaveOccurred())
-
-				Expect(r.Outputs).To(BeEmpty())
-			})
-		})
+				Expect(r.Outputs).To(Equal(storage.JSONObject(nil)))
+			},
+			Entry("null", []byte(`null`)),
+			Entry("empty", []byte(``)),
+			Entry("nil", []byte(nil)),
+		)
 	})
 
 	Describe("ExistsServiceInstanceDetails", func() {


### PR DESCRIPTION
There are some JSON parsing edge cases where we know that we want the
result to be an empty map, but sometimes the JSON parser can fail by
default (to be safer), so we should test that we handle those edge
cases.

[#181522793](https://www.pivotaltracker.com/story/show/181522793)

### Checklist:

* ~~[ ] Have you added or updated tests to validate the changed functionality?~~
* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

