### PR TITLE
fix: log more details when setting up DB connection

### DIFF
--- a/db_service/setup_db.go
+++ b/db_service/setup_db.go
@@ -124,9 +124,11 @@ func setupMysqlDb(logger lager.Logger) (*gorm.DB, error) {
 	}
 
 	logger.Info("Connecting to MySQL Database", lager.Data{
-		"host": dbHost,
-		"port": dbPort,
-		"name": dbName,
+		"host":     dbHost,
+		"port":     dbPort,
+		"name":     dbName,
+		"username": dbUsername,
+		"tls":      tlsStr,
 	})
 
 	connStr := fmt.Sprintf("%v:%v@tcp(%v:%v)/%v?charset=utf8mb4&parseTime=True&loc=Local&timeout=30s%v", dbUsername, dbPassword, dbHost, dbPort, dbName, tlsStr)

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -12,4 +12,5 @@
 - Error messages during encryption tell you how to fix the issue
 - Error messages during encryption log DB row ID
 - Checks the database for readability of all fields before attempting encryption or removing salt
+- Better logging when setting up database connection leading to improved debug experience
 


### PR DESCRIPTION
We recently had to debug a situation where setting up the DB connection
failed. We found this difficult because the logs were quite sparse in
what they recorded. This change adds username and TLS string to the log,
both of which should not contain secrets.

### Checklist:

* ~~[ ] Have you added or updated tests to validate the changed functionality?~~
* [X] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

