### PR TITLE
test: remove terraform providers from manifest for brokerpak integration tests

### DIFF
--- a/brokerpaktestframework/test_instance_builder.go
+++ b/brokerpaktestframework/test_instance_builder.go
@@ -113,6 +113,7 @@ func replaceTerraformBinaries(parsedManifest *manifest.Manifest, terraformBuild 
 			URLTemplate: terraformBuild,
 		},
 	}
+	parsedManifest.TerraformProviders = nil
 	return nil
 }
 


### PR DESCRIPTION
- speeds up the tests while not downloading the depdencies again

### Checklist:

~~* [ ] Have you added or updated tests to validate the changed functionality?~~
~~* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

