### PR TITLE
chore: don't use ioutil package

### DIFF
--- a/brokerpaktestframework/terraform_mock.go
+++ b/brokerpaktestframework/terraform_mock.go
@@ -3,7 +3,6 @@ package brokerpaktestframework
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -14,7 +13,7 @@ import (
 )
 
 func NewTerraformMock() (TerraformMock, error) {
-	dir, err := ioutil.TempDir("", "invocation_store")
+	dir, err := os.MkdirTemp("", "invocation_store")
 	if err != nil {
 		return TerraformMock{}, err
 	}
@@ -45,11 +44,11 @@ func (p TerraformMock) ApplyInvocations() ([]TerraformInvocation, error) {
 }
 
 func (p TerraformMock) Invocations() ([]TerraformInvocation, error) {
-	fileInfo, err := ioutil.ReadDir(p.invocationStore)
+	fileInfo, err := os.ReadDir(p.invocationStore)
 	if err != nil {
 		return nil, err
 	}
-	invocations := []TerraformInvocation{}
+	var invocations []TerraformInvocation
 
 	for _, file := range fileInfo {
 		parts := strings.Split(file.Name(), "-")
@@ -59,7 +58,7 @@ func (p TerraformMock) Invocations() ([]TerraformInvocation, error) {
 }
 
 func (p TerraformMock) Reset() error {
-	dir, err := ioutil.ReadDir(p.invocationStore)
+	dir, err := os.ReadDir(p.invocationStore)
 	if err != nil {
 		return err
 	}

--- a/brokerpaktestframework/test_instance.go
+++ b/brokerpaktestframework/test_instance.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -29,7 +28,7 @@ type TestInstance struct {
 }
 
 func (instance *TestInstance) Start(logger io.Writer, config []string) error {
-	file, err := ioutil.TempFile("", "test-db")
+	file, err := os.CreateTemp("", "test-db")
 	if err != nil {
 		return err
 	}

--- a/brokerpaktestframework/test_instance_builder.go
+++ b/brokerpaktestframework/test_instance_builder.go
@@ -2,7 +2,6 @@ package brokerpaktestframework
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -42,7 +41,7 @@ func BuildTestInstance(brokerPackDir string, provider TerraformMock, logger io.W
 }
 
 func createWorkspace(brokerPackDir string, build string) (string, error) {
-	workingDir, err := ioutil.TempDir("", "prefix")
+	workingDir, err := os.MkdirTemp("", "prefix")
 	if err != nil {
 		return "", err
 	}
@@ -77,7 +76,7 @@ func copyBrokerpackFiles(brokerPackDir string, workingDir string) error {
 }
 
 func templateManifest(brokerPackDir string, build string, workingDir string) error {
-	contents, err := ioutil.ReadFile(path.Join(brokerPackDir, "manifest.yml"))
+	contents, err := os.ReadFile(path.Join(brokerPackDir, "manifest.yml"))
 	if err != nil {
 		return err
 	}

--- a/internal/brokerpak/reader/reader.go
+++ b/internal/brokerpak/reader/reader.go
@@ -197,7 +197,7 @@ func (pak *BrokerPakReader) extractTerraform(r manifest.TerraformVersion, destin
 		return nil
 	}
 
-	// For compatability with brokerpaks built with older versions
+	// For compatibility with brokerpaks built with older versions
 	unversionedPath := path.Join("bin", plat.Os, plat.Arch, "terraform")
 	if pak.fileExistsInZip(unversionedPath) {
 		if err := pak.contents.ExtractFile(unversionedPath, filepath.Join(destination, "versions", r.Version.String())); err != nil {


### PR DESCRIPTION
New code should not use ioutil as its on the path to deprecation

### Checklist:

* ~~[ ] Have you added or updated tests to validate the changed functionality?~~
* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

