### PR TITLE
feat(experimental): store *.pem files alongside Terraform state

### DIFF
--- a/cmd/tf.go
+++ b/cmd/tf.go
@@ -83,7 +83,8 @@ func init() {
 			}
 
 			if onlyState {
-				fmt.Printf("%s", string(ws.State))
+				fmt.Println(string(ws.State))
+				fmt.Printf("%+v\n", ws.AdditionalState)
 			} else {
 				fmt.Println(ws)
 			}

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -2,6 +2,7 @@
 
 ### Features:
 - new "/info" endpoint for diagnostics reports broker version and uptime
+- "*.pem" files get stored alongside Terraform state - experimental and subject to change
 
 ### Fixes:
 

--- a/pkg/brokerpak/config.go
+++ b/pkg/brokerpak/config.go
@@ -17,7 +17,6 @@ package brokerpak
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -160,7 +159,6 @@ func ListBrokerpaks(directory string) ([]string, error) {
 		if err != nil {
 			return err
 		}
-		log.Printf("examining file %v", path)
 		if filepath.Ext(path) == ".brokerpak" {
 			path, err := filepath.Abs(path)
 			if err != nil {

--- a/pkg/providers/tf/workspace/additional_state_test.go
+++ b/pkg/providers/tf/workspace/additional_state_test.go
@@ -1,0 +1,45 @@
+package workspace
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AdditionalStateFiles", func() {
+	Context("saving", func() {
+		It("saves *.pem files", func() {
+			workdir := GinkgoT().TempDir()
+			Expect(os.WriteFile(filepath.Join(workdir, "terraform.tfstate"), []byte("fake-terraform-state"), 0755)).NotTo(HaveOccurred())
+			Expect(os.WriteFile(filepath.Join(workdir, "fake.pem"), []byte("fake-certificate"), 0600)).NotTo(HaveOccurred())
+			w := &TerraformWorkspace{dir: workdir}
+
+			Expect(w.saveState()).NotTo(HaveOccurred())
+
+			Expect(w.State).To(Equal([]byte("fake-terraform-state")))
+			Expect(w.AdditionalState).To(Equal(map[string][]byte{
+				"fake.pem": []byte("fake-certificate"),
+			}))
+		})
+	})
+
+	Context("restoring", func() {
+		It("restores files", func() {
+			workdir := GinkgoT().TempDir()
+			w := &TerraformWorkspace{
+				State: []byte("fake-terraform-state"),
+				AdditionalState: map[string][]byte{
+					"fake.pem": []byte("fake-certificate"),
+				},
+				dir: workdir,
+			}
+
+			Expect(w.restoreState()).NotTo(HaveOccurred())
+
+			Expect(filepath.Join(workdir, "terraform.tfstate")).To(BeAnExistingFile())
+			Expect(filepath.Join(workdir, "fake.pem")).To(BeAnExistingFile())
+		})
+	})
+})

--- a/pkg/providers/tf/workspace/workspace.go
+++ b/pkg/providers/tf/workspace/workspace.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -102,11 +103,11 @@ func DeserializeWorkspace(definition []byte) (*TerraformWorkspace, error) {
 // - The function updates the tfstate once finished.
 // - The function creates and destroys its own dir.
 type TerraformWorkspace struct {
-	Modules   []ModuleDefinition `json:"modules"`
-	Instances []ModuleInstance   `json:"instances"`
-	State     []byte             `json:"tfstate"`
-
-	Transformer TfTransformer `json:"transform"`
+	Modules         []ModuleDefinition `json:"modules"`
+	Instances       []ModuleInstance   `json:"instances"`
+	State           []byte             `json:"tfstate"`
+	AdditionalState map[string][]byte  `json:"additional_state"`
+	Transformer     TfTransformer      `json:"transform"`
 
 	dirLock sync.Mutex
 	dir     string
@@ -235,13 +236,11 @@ func (workspace *TerraformWorkspace) initializeFsModules() error {
 func (workspace *TerraformWorkspace) initializeFsWithoutTerraformInit() error {
 	workspace.dirLock.Lock()
 	// create a temp directory
-	if dir, err := os.MkdirTemp("", "gsb"); err == nil {
-		workspace.dir = dir
-	} else {
+	dir, err := os.MkdirTemp("", "gsb")
+	if err != nil {
 		return err
 	}
-
-	var err error
+	workspace.dir = dir
 
 	terraformLen := 0
 	for _, module := range workspace.Modules {
@@ -261,24 +260,15 @@ func (workspace *TerraformWorkspace) initializeFsWithoutTerraformInit() error {
 		return err
 	}
 
-	// write the state if it exists
-	if len(workspace.State) > 0 {
-		if err = os.WriteFile(workspace.tfStatePath(), workspace.State, 0755); err != nil {
-			return err
-		}
-	}
-	return nil
+	return workspace.restoreState()
 }
 
 // TeardownFs removes the directory we executed Terraform in and updates the
 // state from it.
 func (workspace *TerraformWorkspace) teardownFs() error {
-	bytes, err := os.ReadFile(workspace.tfStatePath())
-	if err != nil {
+	if err := workspace.saveState(); err != nil {
 		return err
 	}
-
-	workspace.State = bytes
 
 	if err := os.RemoveAll(workspace.dir); err != nil {
 		return err
@@ -348,4 +338,48 @@ func (workspace *TerraformWorkspace) ModuleDefinitions() []ModuleDefinition {
 
 func (workspace *TerraformWorkspace) ModuleInstances() []ModuleInstance {
 	return workspace.Instances
+}
+
+func (workspace *TerraformWorkspace) restoreState() error {
+	for f, d := range workspace.AdditionalState {
+		p := filepath.Join(workspace.dir, f)
+		if err := os.WriteFile(p, d, 0600); err != nil {
+			return fmt.Errorf("error writing additional state file %q: %w", p, err)
+		}
+	}
+
+	if len(workspace.State) > 0 {
+		if err := os.WriteFile(workspace.tfStatePath(), workspace.State, 0755); err != nil {
+			return fmt.Errorf("error writing primary state file %q: %w", workspace.tfStatePath(), err)
+		}
+	}
+
+	return nil
+}
+
+func (workspace *TerraformWorkspace) saveState() error {
+	files, err := filepath.Glob(filepath.Join(workspace.dir, "*.pem"))
+	if err != nil {
+		return fmt.Errorf("glob error in %q: %w", workspace.dir, err)
+	}
+
+	for _, f := range files {
+		data, err := os.ReadFile(f)
+		if err != nil {
+			return fmt.Errorf("error reading additional state file: %q: %w", f, err)
+		}
+		if workspace.AdditionalState == nil {
+			workspace.AdditionalState = make(map[string][]byte)
+		}
+		workspace.AdditionalState[filepath.Base(f)] = data
+	}
+
+	data, err := os.ReadFile(workspace.tfStatePath())
+	if err != nil {
+		return fmt.Errorf("error reading primary state file: %q: %w", workspace.tfStatePath(), err)
+	}
+
+	workspace.State = data
+
+	return nil
 }

--- a/pkg/providers/tf/workspace/workspace_suite_test.go
+++ b/pkg/providers/tf/workspace/workspace_suite_test.go
@@ -1,4 +1,4 @@
-package workspace_test
+package workspace
 
 import (
 	"testing"

--- a/pkg/providers/tf/workspace_updater.go
+++ b/pkg/providers/tf/workspace_updater.go
@@ -38,6 +38,7 @@ func UpdateWorkspaceHCL(store broker.ServiceProviderStorage, action TfServiceDef
 	}
 
 	workspace.State = currentWorkspace.State
+	workspace.AdditionalState = currentWorkspace.AdditionalState
 
 	workspaceString, err := workspace.Serialize()
 	if err != nil {

--- a/pkg/providers/tf/workspace_updater_test.go
+++ b/pkg/providers/tf/workspace_updater_test.go
@@ -21,6 +21,8 @@ var _ = Describe("WorkspaceUpdater", func() {
 		lastOperationState   = "fake operation state"
 		lastOperationMessage = "fake operation message"
 		terraformState       = "fake terraform state"
+		additionalStateFile  = "fake.pem"
+		additionalStateData  = "fake additional state"
 		template             = `
 				variable resourceGroup {type = string}
 	
@@ -66,8 +68,9 @@ var _ = Describe("WorkspaceUpdater", func() {
 					ModuleName:   "fake module name",
 					InstanceName: "fake instance name",
 				}},
-				Transformer: workspace.TfTransformer{},
-				State:       []byte(terraformState),
+				Transformer:     workspace.TfTransformer{},
+				State:           []byte(terraformState),
+				AdditionalState: map[string][]byte{additionalStateFile: []byte(additionalStateData)},
 			}
 
 			ws, err := workspace.Serialize()
@@ -144,7 +147,8 @@ var _ = Describe("WorkspaceUpdater", func() {
 					ParametersToRemove: []string{},
 					ParametersToAdd:    []workspace.ParameterMapping{},
 				},
-				State: []byte(terraformState),
+				State:           []byte(terraformState),
+				AdditionalState: map[string][]byte{additionalStateFile: []byte(additionalStateData)},
 			}
 			ew, err := expectedWorkspace.Serialize()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
To support TLS for GCP PostgreSQL, it proved necessary to write
*.pem files for the Terraform provider to use to connect as a client.

This feature is experimental and will change, as the files that are
stored alongside the Terraform state should be configurable.

[#181059797](https://www.pivotaltracker.com/story/show/181059797)

### Checklist:

* [X] Have you added or updated tests to validate the changed functionality?
* [X] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

