### PR TITLE
chore: improve Go version check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,10 @@ PKG="github.com/cloudfoundry/cloud-service-broker"
 .PHONY: deps-go-binary
 deps-go-binary:
 ifeq ($(SKIP_GO_VERSION_CHECK),)
-	echo "Expect: $(GO-VER)" && \
-		echo "Actual: $$($(GO) version)" && \
-	 	$(GO) version | grep $(GO-VER) > /dev/null
+	@@if [ "$$($(GO) version | awk '{print $$3}')" != "${GO-VER}" ]; then \
+		echo "Go version does not match: expected: ${GO-VER}, got $$($(GO) version | awk '{print $$3}')"; \
+		exit 1; \
+	fi
 endif
 
 ###### Help ###################################################################


### PR DESCRIPTION
- new check only prints when there is an error
- new check does not allow substring matches

[#181960182](https://www.pivotaltracker.com/story/show/181960182)

### Checklist:

* ~~[ ] Have you added or updated tests to validate the changed functionality?~~
* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [X] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

