### PR TITLE
test: fix flake after termination service broker instance

### DIFF
--- a/integrationtest/database_encryption_test.go
+++ b/integrationtest/database_encryption_test.go
@@ -343,7 +343,7 @@ var _ = Describe("Database Encryption", func() {
 			Expect(persistedServiceBindingTerraformWorkspace(serviceInstanceGUID, serviceBindingGUID)).To(bePlaintextBindingTerraformState)
 
 			By("restarting the broker with a password")
-			session.Terminate()
+			session.Terminate().Wait()
 			const encryptionPasswords = `[{"primary":true,"label":"my-password","password":{"secret":"supersecretcoolpassword"}}]`
 			session = startBroker(true, encryptionPasswords)
 			Expect(session.Out).To(SatisfyAll(
@@ -363,7 +363,7 @@ var _ = Describe("Database Encryption", func() {
 			Expect(persistedServiceBindingTerraformWorkspace(serviceInstanceGUID, serviceBindingGUID)).NotTo(haveAnyPlaintextBindingTerraformState)
 
 			By("restarting the broker with the same password")
-			session.Terminate()
+			session.Terminate().Wait()
 			session = startBroker(true, encryptionPasswords)
 			Expect(string(session.Out.Contents())).NotTo(ContainSubstring(`cloud-service-broker.rotating-database-encryption`))
 			Expect(session.Out).To(Say(`cloud-service-broker.database-encryption\S*"data":{"primary":"my-password"}}`))
@@ -404,7 +404,7 @@ var _ = Describe("Database Encryption", func() {
 			Expect(persistedServiceBindingTerraformWorkspace(serviceInstanceGUID, serviceBindingGUID)).NotTo(haveAnyPlaintextBindingTerraformState)
 
 			By("restarting the broker with encryption turned off")
-			session.Terminate()
+			session.Terminate().Wait()
 			encryptionPasswords = `[{"primary":false,"label":"my-password","password":{"secret":"supersecretcoolpassword"}}]`
 			session = startBroker(false, encryptionPasswords)
 			Expect(session.Out).To(SatisfyAll(
@@ -424,7 +424,7 @@ var _ = Describe("Database Encryption", func() {
 			Expect(persistedServiceBindingTerraformWorkspace(serviceInstanceGUID, serviceBindingGUID)).To(bePlaintextBindingTerraformState)
 
 			By("restarting the broker with encryption turned off again")
-			session.Terminate()
+			session.Terminate().Wait()
 			session = startBroker(false, "")
 			Expect(string(session.Out.Contents())).NotTo(ContainSubstring(`cloud-service-broker.rotating-database-encryption`))
 			Expect(session.Out).To(Say(`cloud-service-broker.database-encryption\S*"data":{"primary":"none"}}`))
@@ -469,7 +469,7 @@ var _ = Describe("Database Encryption", func() {
 			firstEncryptionPersistedServiceBindingTerraformWorkspace := persistedServiceBindingTerraformWorkspace(serviceInstanceGUID, serviceBindingGUID)
 
 			By("restarting the broker with a different primary password")
-			session.Terminate()
+			session.Terminate().Wait()
 			firstEncryptionPassword = `{"primary":false,"label":"my-first-password","password":{"secret":"supersecretcoolpassword"}}`
 			const secondEncryptionPassword = `{"primary":true,"label":"my-second-password","password":{"secret":"verysecretcoolpassword"}}`
 			encryptionPasswords = fmt.Sprintf("[%s, %s]", firstEncryptionPassword, secondEncryptionPassword)
@@ -500,7 +500,7 @@ var _ = Describe("Database Encryption", func() {
 			Expect(persistedServiceBindingTerraformWorkspace(serviceInstanceGUID, serviceBindingGUID)).NotTo(Equal(firstEncryptionPersistedServiceBindingTerraformWorkspace))
 
 			By("restarting the broker with the new password only")
-			session.Terminate()
+			session.Terminate().Wait()
 			session = startBroker(true, fmt.Sprintf("[%s]", secondEncryptionPassword))
 			Expect(string(session.Out.Contents())).NotTo(ContainSubstring(`cloud-service-broker.rotating-database-encryption`))
 			Expect(session.Out).To(Say(`cloud-service-broker.database-encryption\S*"data":{"primary":"my-second-password"}}`))
@@ -528,7 +528,7 @@ var _ = Describe("Database Encryption", func() {
 				))
 
 				By("restarting the broker with a different primary password and without the initial password")
-				session.Terminate()
+				session.Terminate().Wait()
 				const secondEncryptionPassword = `{"primary":true,"label":"my-second-password","password":{"secret":"verysecretcoolpassword"}}`
 				encryptionPasswords = fmt.Sprintf("[%s]", secondEncryptionPassword)
 				session = startBrokerSession(true, encryptionPasswords)
@@ -574,7 +574,7 @@ var _ = Describe("Database Encryption", func() {
 				Expect(testHelper.DBConn().Save(&record).Error).NotTo(HaveOccurred())
 
 				By("restarting the broker with a different primary password")
-				session.Terminate()
+				session.Terminate().Wait()
 				firstEncryptionPassword = `{"primary":false,"label":"my-first-password","password":{"secret":"supersecretcoolpassword"}}`
 				const secondEncryptionPassword = `{"primary":true,"label":"my-second-password","password":{"secret":"verysecretcoolpassword"}}`
 				encryptionPasswords = fmt.Sprintf("[%s, %s]", firstEncryptionPassword, secondEncryptionPassword)
@@ -639,7 +639,7 @@ var _ = Describe("Database Encryption", func() {
 			By("registering the password")
 			const encryptionPasswords = `[{"label":"obsolete","password":{"secret":"supersecretcoolpassword"}}]`
 			session = startBroker(false, encryptionPasswords)
-			session.Terminate()
+			session.Terminate().Wait()
 
 			var receiver models.PasswordMetadata
 			Expect(testHelper.DBConn().Where("label=?", "obsolete").First(&receiver).Error).NotTo(HaveOccurred())

--- a/integrationtest/terraform_rename_provider_test.go
+++ b/integrationtest/terraform_rename_provider_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Terraform", func() {
 		Eventually(pollLastOperation(testHelper, serviceInstanceGUID), time.Minute*2, lastOperationPollingFrequency).ShouldNot(Equal(domain.InProgress))
 		Expect(pollLastOperation(testHelper, serviceInstanceGUID)()).To(Equal(domain.Succeeded))
 
-		session.Terminate()
+		session.Terminate().Wait()
 
 		testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "brokerpak-terraform-0.13-with-renamed-provider")
 		session = testHelper.StartBroker("TERRAFORM_UPGRADES_ENABLED=true", "BROKERPAK_UPDATES_ENABLED=true")
@@ -66,7 +66,7 @@ var _ = Describe("Terraform", func() {
 		Eventually(pollLastOperation(testHelper, serviceInstanceGUID), time.Minute*2, lastOperationPollingFrequency).ShouldNot(Equal(domain.InProgress))
 		Expect(pollLastOperation(testHelper, serviceInstanceGUID)()).To(Equal(domain.Succeeded))
 
-		session.Terminate()
+		session.Terminate().Wait()
 
 		testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "brokerpak-terraform-0.13-with-renamed-provider")
 		session = testHelper.StartBroker("TERRAFORM_UPGRADES_ENABLED=true", "BROKERPAK_UPDATES_ENABLED=true")
@@ -95,7 +95,7 @@ var _ = Describe("Terraform", func() {
 		Expect(bindingResponse.Error).NotTo(HaveOccurred())
 		Expect(bindingResponse.StatusCode).To(Equal(http.StatusCreated))
 
-		session.Terminate()
+		session.Terminate().Wait()
 
 		testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "brokerpak-terraform-0.13-with-renamed-provider")
 		session = testHelper.StartBroker("TERRAFORM_UPGRADES_ENABLED=true", "BROKERPAK_UPDATES_ENABLED=true")

--- a/integrationtest/terraform_upgrade_0.12_test.go
+++ b/integrationtest/terraform_upgrade_0.12_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Terraform 0.12 Upgrade", func() {
 			Expect(terraformStateVersion(serviceInstanceGUID)).To(Equal("0.12.21"))
 
 			By("updating the brokerpak and restarting the broker")
-			session.Terminate()
+			session.Terminate().Wait()
 			testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "brokerpak-terraform-upgrade")
 
 			session = testHelper.StartBroker("TERRAFORM_UPGRADES_ENABLED=true")
@@ -94,7 +94,7 @@ var _ = Describe("Terraform 0.12 Upgrade", func() {
 			Expect(terraformStateVersion(serviceInstanceGUID)).To(Equal("0.12.21"))
 
 			By("updating the brokerpak and restarting the broker")
-			session.Terminate()
+			session.Terminate().Wait()
 			testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "brokerpak-terraform-upgrade")
 			session = testHelper.StartBroker()
 

--- a/integrationtest/terraform_upgrade_test.go
+++ b/integrationtest/terraform_upgrade_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Terraform Upgrade", func() {
 			Expect(terraformStateVersion(serviceInstanceGUID)).To(Equal("0.13.7"))
 
 			By("updating the brokerpak and restarting the broker")
-			session.Terminate()
+			session.Terminate().Wait()
 			testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "brokerpak-terraform-upgrade")
 
 			session = testHelper.StartBroker("TERRAFORM_UPGRADES_ENABLED=true")
@@ -103,7 +103,7 @@ var _ = Describe("Terraform Upgrade", func() {
 			Expect(terraformStateVersion(serviceInstanceGUID)).To(Equal("0.13.7"))
 
 			By("updating the brokerpak and restarting the broker")
-			session.Terminate()
+			session.Terminate().Wait()
 			testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "brokerpak-terraform-upgrade")
 			session = testHelper.StartBroker()
 

--- a/integrationtest/update_brokerpak_hcl_test.go
+++ b/integrationtest/update_brokerpak_hcl_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Update Brokerpak HCL", func() {
 	}
 
 	pushUpdatedBrokerpak := func(updatesEnabled bool) {
-		session.Terminate()
+		session.Terminate().Wait()
 		testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", updatedBrokerpak)
 		session = startBroker(updatesEnabled)
 	}

--- a/integrationtest/upgrade_terraform_before_delete_test.go
+++ b/integrationtest/upgrade_terraform_before_delete_test.go
@@ -68,7 +68,7 @@ var _ = Describe("upgrade terraform before deprovision", func() {
 				Expect(terraformStateVersion(serviceInstanceGUID)).To(Equal("0.12.21"))
 
 				By("updating the brokerpak and restarting the broker")
-				session.Terminate()
+				session.Terminate().Wait()
 				testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "brokerpak-terraform-upgrade")
 
 				session = testHelper.StartBroker("TERRAFORM_UPGRADES_ENABLED=true")
@@ -105,7 +105,7 @@ var _ = Describe("upgrade terraform before deprovision", func() {
 				Expect(terraformStateVersion(serviceInstanceGUID)).To(Equal("0.12.21"))
 
 				By("updating the brokerpak and restarting the broker")
-				session.Terminate()
+				session.Terminate().Wait()
 				testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "brokerpak-terraform-upgrade")
 
 				session = testHelper.StartBroker("TERRAFORM_UPGRADES_ENABLED=false")

--- a/integrationtest/upgrade_terraform_before_unbind_test.go
+++ b/integrationtest/upgrade_terraform_before_unbind_test.go
@@ -75,7 +75,7 @@ var _ = Describe("upgrade terraform before unbind", func() {
 				Expect(bindResponse.StatusCode).To(Equal(http.StatusCreated))
 
 				By("updating the brokerpak and restarting the broker")
-				session.Terminate()
+				session.Terminate().Wait()
 				testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "brokerpak-terraform-upgrade")
 
 				session = testHelper.StartBroker("TERRAFORM_UPGRADES_ENABLED=true")
@@ -117,7 +117,7 @@ var _ = Describe("upgrade terraform before unbind", func() {
 				Expect(bindResponse.StatusCode).To(Equal(http.StatusCreated))
 
 				By("updating the brokerpak and restarting the broker")
-				session.Terminate()
+				session.Terminate().Wait()
 				testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "brokerpak-terraform-upgrade")
 
 				session = testHelper.StartBroker("TERRAFORM_UPGRADES_ENABLED=false")


### PR DESCRIPTION
[#182117290](https://www.pivotaltracker.com/story/show/182117290)

There were some test flakes in some tests where the broker was stopped an re-started. A theory was that the broker had not completely terminated before the next broker was started and the aliveness test was run, so the aliveness test detected the broker that was shutting down rather than the one that was starting up.

### Checklist:

* ~~[ ] Have you added or updated tests to validate the changed functionality?~~
* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

