### PR TITLE
fix: check readability of deployment workspaces before encryption

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -6,3 +6,4 @@
 
 ### Fixes:
 - brokerpaktestframework.TestInstance.BrokerUrl() has been superseded by BrokerURL(). The original method works but is deprecated. This is to match the Go pseudo-standard on initialisms:  https://github.com/golang/go/wiki/CodeReviewComments#initialisms
+- Checks the database deployment workspace readability before attempting encryption or removing salt

--- a/internal/storage/check_all_records.go
+++ b/internal/storage/check_all_records.go
@@ -3,9 +3,9 @@ package storage
 import (
 	"fmt"
 
-	"github.com/hashicorp/go-multierror"
-
 	"github.com/cloudfoundry/cloud-service-broker/dbservice/models"
+	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf/workspace"
+	"github.com/hashicorp/go-multierror"
 	"gorm.io/gorm"
 )
 
@@ -32,8 +32,7 @@ func (s *Storage) checkAllServiceBindingCredentials() (errs *multierror.Error) {
 	var serviceBindingCredentialsBatch []models.ServiceBindingCredentials
 	result := s.db.FindInBatches(&serviceBindingCredentialsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
 		for i := range serviceBindingCredentialsBatch {
-			_, err := s.decodeJSONObject(serviceBindingCredentialsBatch[i].OtherDetails)
-			if err != nil {
+			if _, err := s.decodeJSONObject(serviceBindingCredentialsBatch[i].OtherDetails); err != nil {
 				errs = multierror.Append(fmt.Errorf("decode error for service binding credential %q: %w", serviceBindingCredentialsBatch[i].BindingID, err), errs)
 			}
 		}
@@ -51,8 +50,7 @@ func (s *Storage) checkAllBindRequestDetails() (errs *multierror.Error) {
 	var bindRequestDetailsBatch []models.BindRequestDetails
 	result := s.db.FindInBatches(&bindRequestDetailsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
 		for i := range bindRequestDetailsBatch {
-			_, err := s.decodeJSONObject(bindRequestDetailsBatch[i].RequestDetails)
-			if err != nil {
+			if _, err := s.decodeJSONObject(bindRequestDetailsBatch[i].RequestDetails); err != nil {
 				errs = multierror.Append(fmt.Errorf("decode error for binding request details %q: %w", bindRequestDetailsBatch[i].ServiceBindingID, err), errs)
 			}
 		}
@@ -70,8 +68,7 @@ func (s *Storage) checkAllProvisionRequestDetails() (errs *multierror.Error) {
 	var provisionRequestDetailsBatch []models.ProvisionRequestDetails
 	result := s.db.FindInBatches(&provisionRequestDetailsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
 		for i := range provisionRequestDetailsBatch {
-			_, err := s.decodeJSONObject(provisionRequestDetailsBatch[i].RequestDetails)
-			if err != nil {
+			if _, err := s.decodeJSONObject(provisionRequestDetailsBatch[i].RequestDetails); err != nil {
 				errs = multierror.Append(fmt.Errorf("decode error for provision request details %q: %w", provisionRequestDetailsBatch[i].ServiceInstanceID, err), errs)
 			}
 		}
@@ -89,8 +86,7 @@ func (s *Storage) checkAllServiceInstanceDetails() (errs *multierror.Error) {
 	var serviceInstanceDetailsBatch []models.ServiceInstanceDetails
 	result := s.db.FindInBatches(&serviceInstanceDetailsBatch, 100, func(tx *gorm.DB, batchNumber int) error {
 		for i := range serviceInstanceDetailsBatch {
-			_, err := s.decodeJSONObject(serviceInstanceDetailsBatch[i].OtherDetails)
-			if err != nil {
+			if _, err := s.decodeJSONObject(serviceInstanceDetailsBatch[i].OtherDetails); err != nil {
 				errs = multierror.Append(fmt.Errorf("decode error for service instance details %q: %w", serviceInstanceDetailsBatch[i].ID, err), errs)
 			}
 		}
@@ -108,8 +104,8 @@ func (s *Storage) checkAllTerraformDeployments() (errs *multierror.Error) {
 	var terraformDeploymentBatch []models.TerraformDeployment
 	result := s.db.FindInBatches(&terraformDeploymentBatch, 100, func(tx *gorm.DB, batchNumber int) error {
 		for i := range terraformDeploymentBatch {
-			_, err := s.decodeJSONObject(terraformDeploymentBatch[i].Workspace)
-			if err != nil {
+			var tfWorkspace workspace.TerraformWorkspace
+			if err := s.decodeJSON(terraformDeploymentBatch[i].Workspace, &tfWorkspace); err != nil {
 				errs = multierror.Append(fmt.Errorf("decode error for terraform deployment %q: %w", terraformDeploymentBatch[i].ID, err), errs)
 			}
 		}

--- a/internal/storage/terraform_deployment.go
+++ b/internal/storage/terraform_deployment.go
@@ -65,9 +65,8 @@ func (s *Storage) GetTerraformDeployment(id string) (TerraformDeployment, error)
 		return TerraformDeployment{}, fmt.Errorf("error finding terraform deployment: %w", err)
 	}
 
-	tfWorkspace := workspace.TerraformWorkspace{}
-	err = s.decodeJSON(receiver.Workspace, &tfWorkspace)
-	if err != nil {
+	var tfWorkspace workspace.TerraformWorkspace
+	if err = s.decodeJSON(receiver.Workspace, &tfWorkspace); err != nil {
 		return TerraformDeployment{}, fmt.Errorf("error decoding workspace %q: %w", id, err)
 	}
 	return TerraformDeployment{


### PR DESCRIPTION
After commit 7542d45 we are able to add more checking to the loading of
deployments from the database at start up. This follows on from commit
76718c026f99702ba710f5717c4a855d1b8825bb, and means that we fail fast
if there is a corrupt entry in the database.

[#182112028](https://www.pivotaltracker.com/story/show/182112028)

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

