### PR TITLE
feat: allow lifecycle.prevent_destroy in HCL

### DIFF
--- a/docs/brokerpak-specification.md
+++ b/docs/brokerpak-specification.md
@@ -517,3 +517,19 @@ There are three directories in the pak's root:
 * `src/` an unstructured directory that holds source code for the bundled binaries, this is for complying with 3rd party licenses.
 * `bin/` contains binaries under `bin/{os}/{arch}` sub-directories for each supported platform.
 * `definitions/` contain the service definition YAML files.
+
+## Terraform lifecycle meta-argument `prevent_destroy`
+Terraform supports a [lifecycle meta-argument called `prevent_destroy`](https://www.terraform.io/language/meta-arguments/lifecycle#prevent_destroy)
+that stops resources from being accidentally destroyed. For example:
+```hcl
+resource "database" "mydatabase" {
+  name = var.database_name
+  lifecycle {
+    prevent_destroy = true
+  }
+```
+It might be that changing the database name would cause the Terraform to delete the
+database and create a new one with the correct name. This can be prevented by adding
+the lifecycle meta-argument `prevent_destroy`. During the deletion of a service instance,
+Cloud Service Broker will set the `prevent_destroy` property to be `false` so that
+the service instance can be deleted.

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -2,7 +2,7 @@
 
 
 ### Features:
-
+- Terraform lifecycle meta-argument `prevent_destroy` is now supported to protect resources during a service update. The property is unset during a deprovision.
 
 ### Fixes:
 - brokerpaktestframework.TestInstance.BrokerUrl() has been superseded by BrokerURL(). The original method works but is deprecated. This is to match the Go pseudo-standard on initialisms:  https://github.com/golang/go/wiki/CodeReviewComments#initialisms

--- a/integrationtest/fixtures/prevent-destroy-during-update/fake-provision.tf
+++ b/integrationtest/fixtures/prevent-destroy-during-update/fake-provision.tf
@@ -1,0 +1,10 @@
+provider "random" { }
+
+variable length { type = number }
+
+resource "random_string" "fake" {
+  length = var.length
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/integrationtest/fixtures/prevent-destroy-during-update/fake-service.yml
+++ b/integrationtest/fixtures/prevent-destroy-during-update/fake-service.yml
@@ -1,0 +1,21 @@
+version: 1
+name: fake-service
+id: df2c1512-3013-11ec-8704-2fbfa9c8a802
+description: description
+display_name: Fake
+image_url: https://example.com/icon.jpg
+documentation_url: https://example.com
+support_url: https://example.com/support.html
+plans:
+- name: first
+  id: e59773ce-3013-11ec-9bbb-9376b4f72d14
+  description: First plan
+  display_name: First
+provision:
+  template_refs:
+    main: fake-provision.tf
+  user_inputs:
+    - field_name: length
+      type: number
+      details: length of random string
+      default: 10

--- a/integrationtest/fixtures/prevent-destroy-during-update/manifest.yml
+++ b/integrationtest/fixtures/prevent-destroy-during-update/manifest.yml
@@ -1,0 +1,17 @@
+packversion: 1
+name: fake-brokerpak
+version: 0.1.0
+metadata:
+  author: noone@nowhere.com
+platforms:
+- os: linux
+  arch: amd64
+- os: darwin
+  arch: amd64
+terraform_binaries:
+- name: terraform
+  version: 0.12.21
+- name: terraform-provider-random
+  version: 2.2.1
+service_definitions:
+- fake-service.yml

--- a/integrationtest/fixtures/update-brokerpak-hcl-updated/fake-provision.tf
+++ b/integrationtest/fixtures/update-brokerpak-hcl-updated/fake-provision.tf
@@ -1,4 +1,4 @@
 variable update_input { type = string }
 variable extra_input { type = string }
 output provision_output { value = "provision output value" }
-output update_output_updated { value = "${var.update_input == null ? "empty" : var.update_input }${var.extra_input == null ? "empty" : var.extra_input}" }
+output update_output_updated { value = "${var.update_input == null ? "empty" : var.update_input}${var.extra_input == null ? "empty" : var.extra_input}" }

--- a/integrationtest/prevent_destroy_during_update_test.go
+++ b/integrationtest/prevent_destroy_during_update_test.go
@@ -1,0 +1,46 @@
+package integrationtest_test
+
+import (
+	"github.com/cloudfoundry/cloud-service-broker/integrationtest/helper"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+)
+
+var _ = Describe("Preventing destroy during update", Ordered, func() {
+	const (
+		serviceOfferingGUID = "df2c1512-3013-11ec-8704-2fbfa9c8a802"
+		servicePlanGUID     = "e59773ce-3013-11ec-9bbb-9376b4f72d14"
+	)
+
+	var (
+		testHelper      *helper.TestHelper
+		serviceInstance helper.ServiceInstance
+		session         *Session
+	)
+
+	BeforeAll(func() {
+		testHelper = helper.New(csb)
+		testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "prevent-destroy-during-update")
+
+		session = testHelper.StartBroker()
+		DeferCleanup(func() {
+			session.Terminate().Wait()
+		})
+	})
+
+	It("provisions with default length", func() {
+		serviceInstance = testHelper.Provision(serviceOfferingGUID, servicePlanGUID)
+	})
+
+	It("fails update when the resource would be deleted", func() {
+		testHelper.Client().Update(serviceInstance.GUID, serviceOfferingGUID, servicePlanGUID, requestID(), []byte(`{"length":5}`))
+		Expect(testHelper.LastOperationFinalState(serviceInstance.GUID)).To(Equal(domain.Failed))
+		Expect(testHelper.LastOperation(serviceInstance.GUID).Description).To(ContainSubstring("Error: Instance cannot be destroyed"))
+	})
+
+	It("can be successfully deleted", func() {
+		testHelper.Deprovision(serviceInstance)
+	})
+})

--- a/integrationtest/update_brokerpak_hcl_test.go
+++ b/integrationtest/update_brokerpak_hcl_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Update Brokerpak HCL", func() {
 		updateParams                = `{"update_input": "update output value"}`
 		updateOutputStateKey        = `"update_output"`
 		updatedUpdateOutputStateKey = `"update_output_updated"`
-		updatedOutputHCL            = `output update_output_updated { value = "${var.update_input == null ? "empty" : var.update_input }${var.extra_input == null ? "empty" : var.extra_input}" }`
+		updatedOutputHCL            = `output update_output_updated { value = "${var.update_input == null ? "empty" : var.update_input}${var.extra_input == null ? "empty" : var.extra_input}" }`
 		initialOutputHCL            = `output update_output { value = "${var.update_input}" }`
 		initialBindingOutputHCL     = `bind_output { value = "${var.provision_output} and bind output value" }`
 		updatedBindingOutputHCL     = `bind_output_updated { value = "${var.provision_output} and bind output value" }`

--- a/pkg/providers/tf/provider.go
+++ b/pkg/providers/tf/provider.go
@@ -114,6 +114,10 @@ func (provider *TerraformProvider) destroy(ctx context.Context, deploymentID str
 
 	workspace := deployment.TFWorkspace()
 
+	if err := workspace.RemovePreventDestroy(); err != nil {
+		return err
+	}
+
 	inputList, err := workspace.Modules[0].Inputs()
 	if err != nil {
 		return err

--- a/pkg/providers/tf/workspace/prevent_destroy.go
+++ b/pkg/providers/tf/workspace/prevent_destroy.go
@@ -15,16 +15,16 @@ const (
 )
 
 func (workspace *TerraformWorkspace) RemovePreventDestroy() error {
-	for i, m := range workspace.Modules {
+	for index, module := range workspace.Modules {
 		var err error
-		workspace.Modules[i].Definition, err = removePreventDestroy(m.Definition)
+		workspace.Modules[index].Definition, err = removePreventDestroy(module.Definition)
 		if err != nil {
-			return fmt.Errorf("HCL parse error for module %d definition: %w", i, err)
+			return fmt.Errorf("HCL parse error for module %d definition: %w", index, err)
 		}
-		for k, v := range workspace.Modules[i].Definitions {
-			workspace.Modules[i].Definitions[k], err = removePreventDestroy(v)
+		for definitionName, definitionContents := range workspace.Modules[index].Definitions {
+			workspace.Modules[index].Definitions[definitionName], err = removePreventDestroy(definitionContents)
 			if err != nil {
-				return fmt.Errorf("HCL parse error for module %d definition %q: %w", i, k, err)
+				return fmt.Errorf("HCL parse error for module %d definition %q: %w", index, definitionName, err)
 			}
 		}
 	}
@@ -32,12 +32,12 @@ func (workspace *TerraformWorkspace) RemovePreventDestroy() error {
 }
 
 func removePreventDestroy(input string) (string, error) {
-	f, diags := hclwrite.ParseConfig([]byte(input), "", hcl.Pos{Line: 1, Column: 1})
+	file, diags := hclwrite.ParseConfig([]byte(input), "", hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
 		return "", diags
 	}
 
-	for _, resource := range f.Body().Blocks() {
+	for _, resource := range file.Body().Blocks() {
 		if resource.Type() == resourceIdentifier {
 			if lifecycle := resource.Body().FirstMatchingBlock(lifecycleIdentifier, nil); lifecycle != nil {
 				if pd := lifecycle.Body().GetAttribute(preventDestroyIdentifier); pd != nil {
@@ -47,5 +47,5 @@ func removePreventDestroy(input string) (string, error) {
 		}
 	}
 
-	return string(f.Bytes()), nil
+	return string(file.Bytes()), nil
 }

--- a/pkg/providers/tf/workspace/prevent_destroy.go
+++ b/pkg/providers/tf/workspace/prevent_destroy.go
@@ -1,0 +1,51 @@
+package workspace
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/zclconf/go-cty/cty"
+)
+
+const (
+	resourceIdentifier       = "resource"
+	lifecycleIdentifier      = "lifecycle"
+	preventDestroyIdentifier = "prevent_destroy"
+)
+
+func (workspace *TerraformWorkspace) RemovePreventDestroy() error {
+	for i, m := range workspace.Modules {
+		var err error
+		workspace.Modules[i].Definition, err = removePreventDestroy(m.Definition)
+		if err != nil {
+			return fmt.Errorf("HCL parse error for module %d definition: %w", i, err)
+		}
+		for k, v := range workspace.Modules[i].Definitions {
+			workspace.Modules[i].Definitions[k], err = removePreventDestroy(v)
+			if err != nil {
+				return fmt.Errorf("HCL parse error for module %d definition %q: %w", i, k, err)
+			}
+		}
+	}
+	return nil
+}
+
+func removePreventDestroy(input string) (string, error) {
+	f, diags := hclwrite.ParseConfig([]byte(input), "", hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return "", diags
+	}
+
+	for _, resource := range f.Body().Blocks() {
+		if resource.Type() == resourceIdentifier {
+			if lifecycle := resource.Body().FirstMatchingBlock(lifecycleIdentifier, nil); lifecycle != nil {
+				if pd := lifecycle.Body().GetAttribute(preventDestroyIdentifier); pd != nil {
+					lifecycle.Body().SetAttributeValue(preventDestroyIdentifier, cty.False)
+				}
+			}
+		}
+	}
+
+	return string(f.Bytes()), nil
+}

--- a/pkg/providers/tf/workspace/prevent_destroy_test.go
+++ b/pkg/providers/tf/workspace/prevent_destroy_test.go
@@ -1,0 +1,151 @@
+package workspace_test
+
+import (
+	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf/workspace"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PreventDestroy", func() {
+	It("can remove `prevent_destroy` directives from definition and definitions", func() {
+		w := workspace.TerraformWorkspace{
+			Modules: []workspace.ModuleDefinition{
+				{
+					Definition: `
+resource "random_string" "one" {
+  length = 10
+  lifecycle {
+    prevent_destroy = true
+  }
+}`,
+					Definitions: map[string]string{
+						"two": `
+resource "random_string" "one" {
+  length = 10
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "random_string" "two" {
+  length = 10
+  lifecycle {
+    ignore_changes  = ["stuff"]
+    prevent_destroy = true
+  }
+}`,
+					},
+				},
+			},
+		}
+
+		Expect(w.RemovePreventDestroy()).NotTo(HaveOccurred())
+
+		Expect(w.Modules[0].Definition).To(Equal(`
+resource "random_string" "one" {
+  length = 10
+  lifecycle {
+    prevent_destroy = false
+  }
+}`,
+		))
+		Expect(w.Modules[0].Definitions).To(HaveKeyWithValue("two", `
+resource "random_string" "one" {
+  length = 10
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+resource "random_string" "two" {
+  length = 10
+  lifecycle {
+    ignore_changes  = ["stuff"]
+    prevent_destroy = false
+  }
+}`,
+		))
+	})
+
+	It("ignores `prevent_destroy` fields not in a `lifecycle` block", func() {
+		w := workspace.TerraformWorkspace{
+			Modules: []workspace.ModuleDefinition{
+				{
+					Definition: `
+resource "random_string" "one" {
+  length          = 10
+  prevent_destroy = true
+}`,
+				},
+			},
+		}
+
+		Expect(w.RemovePreventDestroy()).NotTo(HaveOccurred())
+
+		Expect(w.Modules[0].Definition).To(Equal(`
+resource "random_string" "one" {
+  length          = 10
+  prevent_destroy = true
+}`,
+		))
+	})
+
+	It("ignores `lifecycle` blocks without a `prevent_destroy` field", func() {
+		w := workspace.TerraformWorkspace{
+			Modules: []workspace.ModuleDefinition{
+				{
+					Definition: `
+resource "random_string" "fake" {
+  length = 10
+  lifecycle {
+  }
+}`,
+				},
+			},
+		}
+
+		Expect(w.RemovePreventDestroy()).NotTo(HaveOccurred())
+
+		Expect(w.Modules[0].Definition).To(Equal(`
+resource "random_string" "fake" {
+  length = 10
+  lifecycle {
+  }
+}`,
+		))
+	})
+
+	When("there is an error parsing a single definition", func() {
+		It("returns the error", func() {
+			w := workspace.TerraformWorkspace{
+				Modules: []workspace.ModuleDefinition{
+					{
+						Definition: `bad *** hcl`,
+					},
+				},
+			}
+
+			Expect(w.RemovePreventDestroy()).To(MatchError(ContainSubstring(
+				"HCL parse error for module 0 definition: :1,1-4: Argument or block definition required",
+			)))
+		})
+	})
+
+	When("there is an error parsing one of the definitions", func() {
+		It("returns the error", func() {
+			w := workspace.TerraformWorkspace{
+				Modules: []workspace.ModuleDefinition{
+					{
+						Definitions: map[string]string{
+							"two": `bad *** hcl`,
+						},
+					},
+				},
+			}
+
+			Expect(w.RemovePreventDestroy()).To(MatchError(ContainSubstring(
+				`HCL parse error for module 0 definition "two": :1,1-4: Argument or block definition required`,
+			)))
+		})
+	})
+})


### PR DESCRIPTION
The lifecycle meta-argument `prevent_destroy` prevents Terraform from
accidentally deleting resources. This can now be added in Terraform
definitions to prevent resource from being deleted during an update.
During the delete process, the value is set to `false` so that service
instances can be successfully deleted.

[#181445529](https://www.pivotaltracker.com/story/show/181445529)

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

