### PR TITLE
fix: broker fails to delete service when create in progress

### DIFF
--- a/pkg/providers/tf/deprovision.go
+++ b/pkg/providers/tf/deprovision.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Deprovision performs a terraform destroy on the instance.
-func (provider *TerraformProvider) Deprovision(ctx context.Context, instanceGUID string, details domain.DeprovisionDetails, vc *varcontext.VarContext) (operationID *string, err error) {
+func (provider *TerraformProvider) Deprovision(ctx context.Context, instanceGUID string, _ domain.DeprovisionDetails, vc *varcontext.VarContext) (*string, error) {
 	provider.logger.Debug("terraform-deprovision", correlation.ID(ctx), lager.Data{
 		"instance": instanceGUID,
 	})

--- a/pkg/providers/tf/provider.go
+++ b/pkg/providers/tf/provider.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/cloudfoundry/cloud-service-broker/dbservice/models"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf/executor"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf/invoker"
 	"github.com/hashicorp/go-version"
@@ -110,6 +111,10 @@ func (provider *TerraformProvider) destroy(ctx context.Context, deploymentID str
 	deployment, err := provider.GetTerraformDeployment(deploymentID)
 	if err != nil {
 		return err
+	}
+
+	if deployment.LastOperationType == models.ProvisionOperationType && deployment.LastOperationState == InProgress {
+		return fmt.Errorf("destroy operation not allowed - reason: provision in progress - tf ID: %s", deploymentID)
 	}
 
 	workspace := deployment.TFWorkspace()

--- a/pkg/providers/tf/workspace/workspace.go
+++ b/pkg/providers/tf/workspace/workspace.go
@@ -116,9 +116,15 @@ func (workspace *TerraformWorkspace) StateVersion() (*version.Version, error) {
 	var receiver struct {
 		Version string `json:"terraform_version"`
 	}
-	if err := json.Unmarshal(workspace.State, &receiver); err != nil {
-		return nil, err
+
+	if workspace.State == nil {
+		return nil, fmt.Errorf("workspace state not generated")
 	}
+
+	if err := json.Unmarshal(workspace.State, &receiver); err != nil {
+		return nil, fmt.Errorf("invalid workspace state %w", err)
+	}
+
 	return version.NewVersion(receiver.Version)
 }
 


### PR DESCRIPTION
We want to avoid an error found when trying to delete a service when its creation is in progress as the service is not consolidated and the status of `Terraform` is not generated.

We also avoided an error when reading the `Terraform` state if that state was not previously generated, which generated an error when performing the `Unmarshalling` operation.

[#182125560](https://www.pivotaltracker.com/story/show/182125560)

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

