### PR TITLE
chore: Add tf version to mock terraform and tfState

### DIFF
--- a/brokerpaktestframework/terraform_mock.go
+++ b/brokerpaktestframework/terraform_mock.go
@@ -21,12 +21,13 @@ func NewTerraformMock() (TerraformMock, error) {
 	if err != nil {
 		return TerraformMock{}, err
 	}
-	return TerraformMock{Binary: build, invocationStore: dir}, nil
+	return TerraformMock{Binary: build, invocationStore: dir, Version: "1.1.4"}, nil
 }
 
 type TerraformMock struct {
 	Binary          string
 	invocationStore string
+	Version         string
 }
 
 func (p TerraformMock) ApplyInvocations() ([]TerraformInvocation, error) {
@@ -118,8 +119,9 @@ func (p TerraformMock) SetTFState(values []TFStateValue) error {
 	}
 
 	return p.setTFStateFile(workspace.Tfstate{
-		Version: 4,
-		Outputs: outputs})
+		Version:          4,
+		TerraformVersion: p.Version,
+		Outputs:          outputs})
 }
 
 // ReturnTFState set the Terraform State in a JSON file.

--- a/pkg/providers/tf/workspace/tfstate.go
+++ b/pkg/providers/tf/workspace/tfstate.go
@@ -39,8 +39,9 @@ func NewTfstate(stateFile []byte) (*Tfstate, error) {
 
 // Tfstate is a struct that can help us deserialize the tfstate JSON file.
 type Tfstate struct {
-	Version int `json:"version"`
-	Outputs map[string]struct {
+	Version          int    `json:"version"`
+	TerraformVersion string `json:"terraform_version"`
+	Outputs          map[string]struct {
 		Type  string      `json:"type"`
 		Value interface{} `json:"value"`
 	} `json:"outputs"`


### PR DESCRIPTION
- terraform version from is used when binding to decide if an upgrade is
  needed
- This adds that field to the struct where we parse the state and makes
  it configurable in the mock terraform so it can be set up differently
  for each brokerpak
- This is the simplest implementation. It is worth reviewing when we start testing upgrades in the brokerpaks.

[#182307860](https://www.pivotaltracker.com/story/show/182307860)

### Checklist:

~~* [ ] Have you added or updated tests to validate the changed functionality?~~
~~* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

