### PR TITLE
feat: "tf list" subcommand should print state version

### DIFF
--- a/internal/storage/update_all_records_test.go
+++ b/internal/storage/update_all_records_test.go
@@ -59,9 +59,9 @@ var _ = Describe("UpdateAllRecords", func() {
 			var receiver []models.TerraformDeployment
 			Expect(db.Find(&receiver).Error).NotTo(HaveOccurred())
 			Expect(receiver).To(HaveLen(3))
-			Expect(receiver[0].Workspace).To(Equal([]byte(`{"encrypted":{"decrypted":{"modules":[{"Name":"fake-1","Definition":"","Definitions":null}],"instances":null,"tfstate":null,"transform":{"parameter_mappings":null,"parameters_to_remove":null,"parameters_to_add":null}}}}`)))
-			Expect(receiver[1].Workspace).To(Equal([]byte(`{"encrypted":{"decrypted":{"modules":[{"Name":"fake-2","Definition":"","Definitions":null}],"instances":null,"tfstate":null,"transform":{"parameter_mappings":null,"parameters_to_remove":null,"parameters_to_add":null}}}}`)))
-			Expect(receiver[2].Workspace).To(Equal([]byte(`{"encrypted":{"decrypted":{"modules":[{"Name":"fake-3","Definition":"","Definitions":null}],"instances":null,"tfstate":null,"transform":{"parameter_mappings":null,"parameters_to_remove":null,"parameters_to_add":null}}}}`)))
+			Expect(receiver[0].Workspace).To(Equal(fakeEncryptedWorkspace("fake-1", "1.2.3")))
+			Expect(receiver[1].Workspace).To(Equal(fakeEncryptedWorkspace("fake-2", "")))
+			Expect(receiver[2].Workspace).To(Equal(fakeEncryptedWorkspace("fake-3", "1.2.4")))
 		})
 	})
 


### PR DESCRIPTION
The "cloud-service-broker tf list" command can be used to print a list
of all the Terraform deployments. This adds a new column for to add the
Terraform state version, so it's possible to see what version each
deployment is at. This is expected to be used for debugging purposes.

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

