### PR TITLE
fix: concatenation of words in Terraform error messages

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -30,5 +30,6 @@
 - Brokerpaks no longer include superfluous source code, but if needed it can be including by adding the --include-source option when building
 - brokerpaktestframework.TerraformMock.ReturnTFState() has been superseded by to SetTFState(). The original method works but is deprecated. The goal of this change is to be more precise in terms of the functionality of the method.
 - Broker fails to delete service when create is in progress.
+- Fixes concatenation of words in Terraform error messages
 
 

--- a/pkg/providers/tf/executor/executor.go
+++ b/pkg/providers/tf/executor/executor.go
@@ -78,7 +78,7 @@ func (defaultExecutor) Execute(ctx context.Context, c *exec.Cmd) (ExecutionOutpu
 	})
 
 	if err != nil {
-		return ExecutionOutput{}, fmt.Errorf("%s %v", strings.ReplaceAll(string(errors), "\n", ""), err)
+		return ExecutionOutput{}, fmt.Errorf("%s %w", strings.ReplaceAll(string(errors), "\n", " "), err)
 	}
 
 	return ExecutionOutput{


### PR DESCRIPTION
### Checklist:

* ~~[ ] Have you added or updated tests to validate the changed functionality?~~
* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

