### PR TITLE
fix: double spaced error messages

### DIFF
--- a/pkg/providers/tf/deployment_manager.go
+++ b/pkg/providers/tf/deployment_manager.go
@@ -59,14 +59,14 @@ func (d *DeploymentManager) MarkOperationFinished(deployment *storage.TerraformD
 		outputs, err := workspace.Outputs(workspace.ModuleInstances()[0].InstanceName)
 		if err == nil {
 			if status, ok := outputs["status"]; ok {
-				lastOperationMessage = fmt.Sprintf("%s %s: %v", deployment.LastOperationType, Succeeded, status)
+				lastOperationMessage = fmt.Sprintf("%s %s: %s", deployment.LastOperationType, Succeeded, status)
 			}
 		}
 		deployment.LastOperationState = Succeeded
 		deployment.LastOperationMessage = lastOperationMessage
 	} else {
 		deployment.LastOperationState = Failed
-		deployment.LastOperationMessage = fmt.Errorf("%s %s: %w", deployment.LastOperationType, Failed, err).Error()
+		deployment.LastOperationMessage = fmt.Sprintf("%s %s: %s", deployment.LastOperationType, Failed, err)
 	}
 
 	return d.store.StoreTerraformDeployment(*deployment)

--- a/pkg/providers/tf/executor/executor.go
+++ b/pkg/providers/tf/executor/executor.go
@@ -78,13 +78,23 @@ func (defaultExecutor) Execute(ctx context.Context, c *exec.Cmd) (ExecutionOutpu
 	})
 
 	if err != nil {
-		return ExecutionOutput{}, fmt.Errorf("%s %w", strings.ReplaceAll(string(errors), "\n", " "), err)
+		return ExecutionOutput{}, fmt.Errorf("%s %w", flatten(errors), err)
 	}
 
 	return ExecutionOutput{
 		StdErr: string(errors),
 		StdOut: string(output),
 	}, nil
+}
+
+func flatten(input []byte) string {
+	var lines []string
+	for _, l := range strings.Split(string(input), "\n") {
+		if line := strings.TrimSpace(l); len(line) > 0 {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, " ")
 }
 
 // CustomTerraformExecutor executes a custom Terraform binary that uses plugins


### PR DESCRIPTION
In the previous commit, a fix was made to stop concatenating words in
error messages. This occurred because the newline was previously being
removed, and this was changed to replace it with a space. But sometimes
there is a leading newline or a newline following a space. In these
cases error messages now appear to have double spaces in them which
looks as bad as concatenation, and also causes error message tests to
fail. This commit is aimed at fixing this formatting issues so that
multi-line strings should be converted to normal looking single lines.

### Checklist:

* ~~[ ] Have you added or updated tests to validate the changed functionality?~~
* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

