### PR TITLE
feat: allow upgrade of Terraform modules

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -10,6 +10,7 @@
     - Update endpoint can perform upgrades when the correct maintenance info information is passed and no other changes
       are requested. This will upgrade the instance and all related bindings.
     - Update, bind, unbind and delete operations are blocked if an upgrade has not happened first.
+    - Terraform modules can also be upgraded
 - The `tf list` subcommand now prints the version of Terraform for each workspace state
 - A new "purge" subcommand can be used to remove a service instance from the database
 

--- a/integrationtest/fixtures/terraform-module-upgrade-updated/fake-provision.tf
+++ b/integrationtest/fixtures/terraform-module-upgrade-updated/fake-provision.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "3.1.0"
+    }
+  }
+}
+
+resource "random_password" "password" {
+  length = 5
+}
+
+output "provision_output" {
+  value = random_password.password.result
+}

--- a/integrationtest/fixtures/terraform-module-upgrade-updated/fake-service.yml
+++ b/integrationtest/fixtures/terraform-module-upgrade-updated/fake-service.yml
@@ -1,0 +1,26 @@
+version: 1
+name: fake-service
+id: df2c1512-3013-11ec-8704-2fbfa9c8a802
+description: description
+display_name: Fake
+image_url: https://example.com/icon.jpg
+documentation_url: https://example.com
+support_url: https://example.com/support.html
+plans:
+  - name: first
+    id: e59773ce-3013-11ec-9bbb-9376b4f72d14
+    description: First plan
+    display_name: First
+provision:
+  template_ref: fake-provision.tf
+  outputs:
+    - field_name: provision_output
+      type: string
+      details: provision output
+bind:
+  template_ref: fake-provision.tf
+  outputs:
+    - field_name: provision_output
+      type: string
+      details: provision output
+

--- a/integrationtest/fixtures/terraform-module-upgrade-updated/manifest.yml
+++ b/integrationtest/fixtures/terraform-module-upgrade-updated/manifest.yml
@@ -1,0 +1,34 @@
+packversion: 1
+name: fake-brokerpak
+version: 0.1.0
+metadata:
+  author: noone@nowhere.com
+platforms:
+- os: linux
+  arch: amd64
+- os: darwin
+  arch: amd64
+terraform_binaries:
+- name: terraform
+  version: 0.12.21
+- name: terraform
+  version: 0.13.7
+- name: terraform
+  version: 0.14.9
+- name: terraform
+  version: 1.0.10
+- name: terraform
+  version: 1.1.6
+  default: true
+- name: terraform-provider-random
+  version: 3.1.0
+terraform_state_provider_replacements:
+  registry.terraform.io/-/random: "registry.terraform.io/hashicorp/random"
+terraform_upgrade_path:
+- version: 0.12.21
+- version: 0.13.7
+- version: 0.14.9
+- version: 1.0.10
+- version: 1.1.6
+service_definitions:
+- fake-service.yml

--- a/integrationtest/fixtures/terraform-module-upgrade/fake-provision.tf
+++ b/integrationtest/fixtures/terraform-module-upgrade/fake-provision.tf
@@ -1,0 +1,9 @@
+provider "random" { }
+
+resource "random_password" "password" {
+  length = 5
+}
+
+output "provision_output" {
+  value = random_password.password.result
+}

--- a/integrationtest/fixtures/terraform-module-upgrade/fake-service.yml
+++ b/integrationtest/fixtures/terraform-module-upgrade/fake-service.yml
@@ -1,0 +1,25 @@
+version: 1
+name: fake-service
+id: df2c1512-3013-11ec-8704-2fbfa9c8a802
+description: description
+display_name: Fake
+image_url: https://example.com/icon.jpg
+documentation_url: https://example.com
+support_url: https://example.com/support.html
+plans:
+- name: first
+  id: e59773ce-3013-11ec-9bbb-9376b4f72d14
+  description: First plan
+  display_name: First
+provision:
+  template_ref: fake-provision.tf
+  outputs:
+    - field_name: provision_output
+      type: string
+      details: provision output
+bind:
+  template_ref: fake-provision.tf
+  outputs:
+    - field_name: provision_output
+      type: string
+      details: provision output

--- a/integrationtest/fixtures/terraform-module-upgrade/manifest.yml
+++ b/integrationtest/fixtures/terraform-module-upgrade/manifest.yml
@@ -1,0 +1,18 @@
+packversion: 1
+name: fake-brokerpak
+version: 0.1.0
+metadata:
+  author: noone@nowhere.com
+platforms:
+- os: linux
+  arch: amd64
+- os: darwin
+  arch: amd64
+terraform_binaries:
+- name: terraform
+  version: 0.12.21
+- name: terraform-provider-random
+  version: 3.1.0
+  source: https://github.com/terraform-providers/terraform-provider-random/archive/v3.1.0.zip
+service_definitions:
+- fake-service.yml

--- a/integrationtest/terraform_module_upgrade_test.go
+++ b/integrationtest/terraform_module_upgrade_test.go
@@ -1,0 +1,86 @@
+package integrationtest_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/pborman/uuid"
+
+	"github.com/cloudfoundry/cloud-service-broker/integrationtest/helper"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+)
+
+var _ = Describe("Terraform Module Upgrade", func() {
+	const (
+		serviceOfferingGUID = "df2c1512-3013-11ec-8704-2fbfa9c8a802"
+		servicePlanGUID     = "e59773ce-3013-11ec-9bbb-9376b4f72d14"
+	)
+
+	var (
+		testHelper *helper.TestHelper
+		session    *Session
+	)
+
+	instanceTerraformStateVersion := func(serviceInstanceGUID string) string {
+		return terraformStateVersion(fmt.Sprintf("tf:%s:", serviceInstanceGUID), testHelper)
+	}
+
+	bindingTerraformStateVersion := func(serviceInstanceGUID, bindingGUID string) string {
+		return terraformStateVersion(fmt.Sprintf("tf:%s:%s", serviceInstanceGUID, bindingGUID), testHelper)
+	}
+
+	BeforeEach(func() {
+		testHelper = helper.New(csb)
+		testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "terraform-module-upgrade")
+
+		session = testHelper.StartBroker()
+
+		DeferCleanup(func() {
+			session.Terminate().Wait()
+		})
+	})
+
+	Context("TF Upgrades are enabled", func() {
+		It("runs 'terraform apply' at each version in the upgrade path", func() {
+			By("provisioning a service instance at 0.12")
+			serviceInstance := testHelper.Provision(serviceOfferingGUID, servicePlanGUID)
+			Expect(instanceTerraformStateVersion(serviceInstance.GUID)).To(Equal("0.12.21"))
+
+			By("creating service bindings")
+			firstBindGUID := uuid.New()
+			firstBindResponse := testHelper.Client().Bind(serviceInstance.GUID, firstBindGUID, serviceOfferingGUID, servicePlanGUID, requestID(), nil)
+			Expect(firstBindResponse.Error).NotTo(HaveOccurred())
+			Expect(firstBindResponse.StatusCode).To(Equal(http.StatusCreated))
+
+			secondBindGUID := uuid.New()
+			secondBindResponse := testHelper.Client().Bind(serviceInstance.GUID, secondBindGUID, serviceOfferingGUID, servicePlanGUID, requestID(), nil)
+			Expect(secondBindResponse.Error).NotTo(HaveOccurred())
+			Expect(secondBindResponse.StatusCode).To(Equal(http.StatusCreated))
+
+			By("updating the brokerpak and restarting the broker")
+			session.Terminate().Wait()
+			testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "terraform-module-upgrade-updated")
+
+			session = testHelper.StartBroker(
+				"TERRAFORM_UPGRADES_ENABLED=true",
+				"BROKERPAK_UPDATES_ENABLED=true",
+			)
+
+			By("validating old state")
+			Expect(instanceTerraformStateVersion(serviceInstance.GUID)).To(Equal("0.12.21"))
+			Expect(bindingTerraformStateVersion(serviceInstance.GUID, firstBindGUID)).To(Equal("0.12.21"))
+			Expect(bindingTerraformStateVersion(serviceInstance.GUID, secondBindGUID)).To(Equal("0.12.21"))
+
+			By("running 'cf update-service'")
+			testHelper.UpgradeService(serviceInstance, domain.PreviousValues{PlanID: servicePlanGUID}, domain.MaintenanceInfo{Version: "1.1.6"})
+
+			By("observing that the instance TF state file has been updated to the latest version")
+			Expect(instanceTerraformStateVersion(serviceInstance.GUID)).To(Equal("1.1.6"))
+			Expect(bindingTerraformStateVersion(serviceInstance.GUID, firstBindGUID)).To(Equal("1.1.6"))
+			Expect(bindingTerraformStateVersion(serviceInstance.GUID, secondBindGUID)).To(Equal("1.1.6"))
+		})
+	})
+})

--- a/pkg/providers/tf/workspace/instance.go
+++ b/pkg/providers/tf/workspace/instance.go
@@ -38,7 +38,10 @@ func (instance *ModuleInstance) MarshalDefinition(outputs []string) (json.RawMes
 
 	outputMap := make(map[string]interface{})
 	for _, variable := range outputs {
-		outputMap[variable] = map[string]string{"value": fmt.Sprintf("${module.%s.%s}", instance.InstanceName, variable)}
+		outputMap[variable] = map[string]any{
+			"value":     fmt.Sprintf("${module.%s.%s}", instance.InstanceName, variable),
+			"sensitive": true,
+		}
 	}
 
 	defn := map[string]interface{}{

--- a/pkg/providers/tf/workspace/instance_test.go
+++ b/pkg/providers/tf/workspace/instance_test.go
@@ -30,7 +30,7 @@ func ExampleModuleInstance_MarshalDefinition() {
 	fmt.Printf("%s\n", string(defnJSON))
 
 	// Output: <nil>
-	// {"module":{"instance":{"foo":"bar","source":"./foo-module"}},"output":{"output1":{"value":"${module.instance.output1}"},"output2":{"value":"${module.instance.output2}"}}}
+	// {"module":{"instance":{"foo":"bar","source":"./foo-module"}},"output":{"output1":{"sensitive":true,"value":"${module.instance.output1}"},"output2":{"sensitive":true,"value":"${module.instance.output2}"}}}
 }
 
 func ExampleModuleInstance_MarshalDefinition_emptyOutputs() {


### PR DESCRIPTION
Terraform modules are a feature in Terraform. Most of our work
on the Terraform upgrade path has specified Terraform via `template_refs`
which results in not using Terraform modules. However if Terraform is
specified via `template_ref` then a single Terraform module is created.
The outputs from this module used not to be marked as "sensitive" which
meant that Terraform would fail if an output referred to a sensitive
value, which meant that we could not upgrade past Terraform 0.14. This
commit marks all the module outputs as sensitive. This is ignored by
earlier versions of Terraform, and allows for services using Terraform
modules to be upgraded to the latest Terraform version.

[#182413672](https://www.pivotaltracker.com/story/show/182413672)

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

