### PR TITLE
chore: update decider should not look up plan

### DIFF
--- a/brokerapi/broker/broker.go
+++ b/brokerapi/broker/broker.go
@@ -129,5 +129,5 @@ func generateTFBindingID(instanceID, bindingID string) string {
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . Decider
 type Decider interface {
-	DecideOperation(serviceDefinition *broker.ServiceDefinition, details domain.UpdateDetails) (decider.Operation, error)
+	DecideOperation(planMaintenanceInfo *domain.MaintenanceInfo, details domain.UpdateDetails) (decider.Operation, error)
 }

--- a/brokerapi/broker/brokerfakes/fake_decider.go
+++ b/brokerapi/broker/brokerfakes/fake_decider.go
@@ -6,15 +6,14 @@ import (
 
 	"github.com/cloudfoundry/cloud-service-broker/brokerapi/broker"
 	"github.com/cloudfoundry/cloud-service-broker/brokerapi/broker/decider"
-	brokera "github.com/cloudfoundry/cloud-service-broker/pkg/broker"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 )
 
 type FakeDecider struct {
-	DecideOperationStub        func(*brokera.ServiceDefinition, domain.UpdateDetails) (decider.Operation, error)
+	DecideOperationStub        func(*domain.MaintenanceInfo, domain.UpdateDetails) (decider.Operation, error)
 	decideOperationMutex       sync.RWMutex
 	decideOperationArgsForCall []struct {
-		arg1 *brokera.ServiceDefinition
+		arg1 *domain.MaintenanceInfo
 		arg2 domain.UpdateDetails
 	}
 	decideOperationReturns struct {
@@ -29,11 +28,11 @@ type FakeDecider struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeDecider) DecideOperation(arg1 *brokera.ServiceDefinition, arg2 domain.UpdateDetails) (decider.Operation, error) {
+func (fake *FakeDecider) DecideOperation(arg1 *domain.MaintenanceInfo, arg2 domain.UpdateDetails) (decider.Operation, error) {
 	fake.decideOperationMutex.Lock()
 	ret, specificReturn := fake.decideOperationReturnsOnCall[len(fake.decideOperationArgsForCall)]
 	fake.decideOperationArgsForCall = append(fake.decideOperationArgsForCall, struct {
-		arg1 *brokera.ServiceDefinition
+		arg1 *domain.MaintenanceInfo
 		arg2 domain.UpdateDetails
 	}{arg1, arg2})
 	stub := fake.DecideOperationStub
@@ -55,13 +54,13 @@ func (fake *FakeDecider) DecideOperationCallCount() int {
 	return len(fake.decideOperationArgsForCall)
 }
 
-func (fake *FakeDecider) DecideOperationCalls(stub func(*brokera.ServiceDefinition, domain.UpdateDetails) (decider.Operation, error)) {
+func (fake *FakeDecider) DecideOperationCalls(stub func(*domain.MaintenanceInfo, domain.UpdateDetails) (decider.Operation, error)) {
 	fake.decideOperationMutex.Lock()
 	defer fake.decideOperationMutex.Unlock()
 	fake.DecideOperationStub = stub
 }
 
-func (fake *FakeDecider) DecideOperationArgsForCall(i int) (*brokera.ServiceDefinition, domain.UpdateDetails) {
+func (fake *FakeDecider) DecideOperationArgsForCall(i int) (*domain.MaintenanceInfo, domain.UpdateDetails) {
 	fake.decideOperationMutex.RLock()
 	defer fake.decideOperationMutex.RUnlock()
 	argsForCall := fake.decideOperationArgsForCall[i]

--- a/brokerapi/broker/update.go
+++ b/brokerapi/broker/update.go
@@ -93,7 +93,7 @@ func (broker *ServiceBroker) Update(ctx context.Context, instanceID string, deta
 		return domain.UpdateServiceSpec{}, err
 	}
 
-	operation, err := broker.decider.DecideOperation(serviceDefinition, details)
+	operation, err := broker.decider.DecideOperation(plan.MaintenanceInfo, details)
 	switch {
 	case err != nil:
 		return domain.UpdateServiceSpec{}, fmt.Errorf("error deciding update path: %w", err)


### PR DESCRIPTION
The update decider has been changed so that it does not look up the
plan, but instead takes the MaintenanceInfo of the plan that has already
been looked up in the Update() method.

The disadvantage of this is it will no longer support different plans
having different MaintenanceInfo, but this is not something supported at
this time.

[#181155154](https://www.pivotaltracker.com/story/show/181155154)

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

