### PR TITLE
chore: update decider should used pre-parsed data

### DIFF
--- a/brokerapi/broker/update.go
+++ b/brokerapi/broker/update.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cloudfoundry/cloud-service-broker/brokerapi/broker/decider"
 	"github.com/cloudfoundry/cloud-service-broker/internal/storage"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/broker"
+	"github.com/hashicorp/go-version"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/cloudfoundry/cloud-service-broker/internal/paramparser"
@@ -59,6 +60,10 @@ func (broker *ServiceBroker) Update(ctx context.Context, instanceID string, deta
 	if err != nil {
 		return domain.UpdateServiceSpec{}, err
 	}
+	maintenanceInfoVersion, err := planMaintenanceInfoVersion(plan)
+	if err != nil {
+		return domain.UpdateServiceSpec{}, err
+	}
 
 	// verify async provisioning is allowed if it is required
 	if !asyncAllowed {
@@ -93,7 +98,7 @@ func (broker *ServiceBroker) Update(ctx context.Context, instanceID string, deta
 		return domain.UpdateServiceSpec{}, err
 	}
 
-	operation, err := decider.DecideOperation(plan.MaintenanceInfo, details)
+	operation, err := decider.DecideOperation(maintenanceInfoVersion, parsedDetails)
 	switch {
 	case err != nil:
 		return domain.UpdateServiceSpec{}, fmt.Errorf("error deciding update path: %w", err)
@@ -190,4 +195,15 @@ func mergeJSON(previousParams, newParams, importParams map[string]interface{}) (
 	}
 
 	return vc.ToMap(), nil
+}
+
+func planMaintenanceInfoVersion(plan *broker.ServicePlan) (*version.Version, error) {
+	if plan.MaintenanceInfo != nil && len(plan.MaintenanceInfo.Version) != 0 {
+		maintenanceInfoVersion, err := version.NewVersion(plan.MaintenanceInfo.Version)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing plan maintenance info version: %w", err)
+		}
+		return maintenanceInfoVersion, nil
+	}
+	return nil, nil
 }

--- a/internal/paramparser/parse_update_details.go
+++ b/internal/paramparser/parse_update_details.go
@@ -4,18 +4,21 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/hashicorp/go-version"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 )
 
 type UpdateDetails struct {
-	ServiceID         string
-	PlanID            string
-	PreviousPlanID    string
-	PreviousServiceID string
-	PreviousOrgID     string
-	PreviousSpaceID   string
-	RequestParams     map[string]interface{}
-	RequestContext    map[string]interface{}
+	ServiceID                      string
+	PlanID                         string
+	MaintenanceInfoVersion         *version.Version
+	PreviousPlanID                 string
+	PreviousServiceID              string
+	PreviousOrgID                  string
+	PreviousSpaceID                string
+	PreviousMaintenanceInfoVersion *version.Version
+	RequestParams                  map[string]any
+	RequestContext                 map[string]any
 }
 
 func ParseUpdateDetails(input domain.UpdateDetails) (UpdateDetails, error) {
@@ -38,6 +41,22 @@ func ParseUpdateDetails(input domain.UpdateDetails) (UpdateDetails, error) {
 		if err := json.Unmarshal(input.RawContext, &result.RequestContext); err != nil {
 			return UpdateDetails{}, fmt.Errorf("error parsing request context: %w", err)
 		}
+	}
+
+	if input.MaintenanceInfo != nil && len(input.MaintenanceInfo.Version) != 0 {
+		v, err := version.NewVersion(input.MaintenanceInfo.Version)
+		if err != nil {
+			return UpdateDetails{}, fmt.Errorf("error parsing maintenance info: %w", err)
+		}
+		result.MaintenanceInfoVersion = v
+	}
+
+	if input.PreviousValues.MaintenanceInfo != nil && len(input.PreviousValues.MaintenanceInfo.Version) != 0 {
+		v, err := version.NewVersion(input.PreviousValues.MaintenanceInfo.Version)
+		if err != nil {
+			return UpdateDetails{}, fmt.Errorf("error parsing previous maintenance info: %w", err)
+		}
+		result.PreviousMaintenanceInfoVersion = v
 	}
 
 	return result, nil

--- a/internal/paramparser/parse_update_details_test.go
+++ b/internal/paramparser/parse_update_details_test.go
@@ -2,6 +2,7 @@ package paramparser_test
 
 import (
 	"github.com/cloudfoundry/cloud-service-broker/internal/paramparser"
+	"github.com/hashicorp/go-version"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
@@ -10,28 +11,36 @@ import (
 var _ = Describe("ParseUpdateDetails", func() {
 	It("can parse update details", func() {
 		ud, err := paramparser.ParseUpdateDetails(domain.UpdateDetails{
-			ServiceID:     "fake-service-id",
-			PlanID:        "fake-plan-id",
+			ServiceID: "fake-service-id",
+			PlanID:    "fake-plan-id",
+			MaintenanceInfo: &domain.MaintenanceInfo{
+				Version: "1.2.3",
+			},
 			RawParameters: []byte(`{"foo":"bar"}`),
 			PreviousValues: domain.PreviousValues{
 				PlanID:    "fake-previous-plan-id",
 				ServiceID: "fake-previous-service-id",
 				OrgID:     "fake-previous-org-id",
 				SpaceID:   "fake-previous-space-id",
+				MaintenanceInfo: &domain.MaintenanceInfo{
+					Version: "0.1.2",
+				},
 			},
 			RawContext: []byte(`{"baz":"quz"}`),
 		})
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ud).To(Equal(paramparser.UpdateDetails{
-			ServiceID:         "fake-service-id",
-			PlanID:            "fake-plan-id",
-			RequestParams:     map[string]interface{}{"foo": "bar"},
-			RequestContext:    map[string]interface{}{"baz": "quz"},
-			PreviousPlanID:    "fake-previous-plan-id",
-			PreviousServiceID: "fake-previous-service-id",
-			PreviousOrgID:     "fake-previous-org-id",
-			PreviousSpaceID:   "fake-previous-space-id",
+			ServiceID:                      "fake-service-id",
+			PlanID:                         "fake-plan-id",
+			MaintenanceInfoVersion:         version.Must(version.NewVersion("1.2.3")),
+			RequestParams:                  map[string]any{"foo": "bar"},
+			RequestContext:                 map[string]any{"baz": "quz"},
+			PreviousPlanID:                 "fake-previous-plan-id",
+			PreviousServiceID:              "fake-previous-service-id",
+			PreviousOrgID:                  "fake-previous-org-id",
+			PreviousSpaceID:                "fake-previous-space-id",
+			PreviousMaintenanceInfoVersion: version.Must(version.NewVersion("0.1.2")),
 		}))
 	})
 
@@ -57,9 +66,51 @@ var _ = Describe("ParseUpdateDetails", func() {
 		})
 	})
 
+	When("maintenance info version is not valid", func() {
+		It("returns an error", func() {
+			ud, err := paramparser.ParseUpdateDetails(domain.UpdateDetails{
+				MaintenanceInfo: &domain.MaintenanceInfo{
+					Version: "not-a-valid-version",
+				},
+			})
+
+			Expect(err).To(MatchError(`error parsing maintenance info: Malformed version: not-a-valid-version`))
+			Expect(ud).To(BeZero())
+		})
+	})
+
+	When("previous maintenance info version is not valid", func() {
+		It("returns an error", func() {
+			ud, err := paramparser.ParseUpdateDetails(domain.UpdateDetails{
+				PreviousValues: domain.PreviousValues{
+					MaintenanceInfo: &domain.MaintenanceInfo{
+						Version: "not-a-valid-version",
+					},
+				},
+			})
+
+			Expect(err).To(MatchError(`error parsing previous maintenance info: Malformed version: not-a-valid-version`))
+			Expect(ud).To(BeZero())
+		})
+	})
+
 	When("input is empty", func() {
 		It("succeeds with an empty result", func() {
 			ud, err := paramparser.ParseUpdateDetails(domain.UpdateDetails{})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ud).To(BeZero())
+		})
+	})
+
+	When("maintenance_info versions are empty", func() {
+		It("succeeds with an empty result", func() {
+			ud, err := paramparser.ParseUpdateDetails(domain.UpdateDetails{
+				MaintenanceInfo: &domain.MaintenanceInfo{},
+				PreviousValues: domain.PreviousValues{
+					MaintenanceInfo: &domain.MaintenanceInfo{},
+				},
+			})
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ud).To(BeZero())


### PR DESCRIPTION
We introduced `paramparser.ParseUpdateDetails()` to act as an
abstraction layer between the `github.com/pivotal-cf/brokerapi`
library and other code in the Cloud Service Broker. This stops
brokerapi concepts and types from leaking across the whole codebase, and
it allows us to shape the data into the form that is needed. The update
decider did not follow this pattern, and it has now been updated to do
so. This leads to considerable simplification of the update decider code.

[#181155154](https://www.pivotaltracker.com/story/show/181155154)

### Checklist:

* ~~[ ] Have you added or updated tests to validate the changed functionality?~~
* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

