### PR TITLE
fix: ability to update after an upgrade

### DIFF
--- a/brokerapi/broker/decider/decider.go
+++ b/brokerapi/broker/decider/decider.go
@@ -35,28 +35,38 @@ func DecideOperation(planMaintenanceInfoVersion *version.Version, details paramp
 	// So it's an attempt to upgrade and update at the same time.
 	invalidUpdateAndMIChange := requestHasUpdate && requestHasMI && !details.MaintenanceInfoVersion.Equal(details.PreviousMaintenanceInfoVersion)
 
-	// There's an update to plan/parameters, no new MI, plan does not have MI, but there's a previous MI value, so
-	// it looks like we are trying to change version (to having no MI) at the same time as an update.
-	// Valid options would be:
-	// - update to plan/parameters with previous MI the same as plan MI
-	// - upgrade to the no-MI plan with no updates of plan/parameters
+	// When there is no MI in the request, this might be because the MI is not being changed (Update),
+	// or it might be because MI is being removed (which would be an Upgrade)
+	// Here we have:
+	// - an update to plan/parameters (which would be invalid to combine with an Upgrade)
+	// - no new MI, which could imply no change to MI (as in Update of plan/params), or could be a removal of MI (for Upgrade)
+	// - previous MI, so the instance currently has a maintenance info version
+	// - no plan MI, so the requested MI and plan MI match - hence it would not trigger the ErrMaintenanceInfoConflict error
+	// This is an error because it's a combined Update and Upgrade. The valid MI change should be performed first,
+	// and then the other fields can be updated in a later request
 	invalidUpdateAndMIRemoval := requestHasUpdate && !requestHasMI && requestHasPreviousMI && planMaintenanceInfoVersion == nil
 
 	switch {
 	case requestHasMI && planMaintenanceInfoVersion == nil:
-		// new MI is specified in request, but plan does not have MI
+		// error: new MI is specified in request, but plan does not have MI
 		return Failed, apiresponses.ErrMaintenanceInfoNilConflict
 	case requestHasMI && !planMaintenanceInfoVersion.Equal(details.MaintenanceInfoVersion):
-		// new MI is specified, and doesn't match the plan MI
+		// error: new MI is specified, and doesn't match the plan MI
 		return Failed, apiresponses.ErrMaintenanceInfoConflict
 	case invalidUpdateAndMIChange, invalidUpdateAndMIRemoval:
-		// invalid mixing of an update with an attempt to change MI
+		// error: invalid mixing of an update with an attempt to change MI
 		return Failed, errInstanceMustBeUpgradedFirst()
-	case !requestHasUpdate && !details.MaintenanceInfoVersion.Equal(details.PreviousMaintenanceInfoVersion):
-		// MI changed and no updates, so must be an upgrade
+	case !requestHasMI && !requestHasUpdate && planMaintenanceInfoVersion == nil && details.PreviousMaintenanceInfoVersion != nil:
+		// MI removal: no MI in request because MI is being removed to match plan, and previous MI means it's a valid Upgrade
 		return Upgrade, nil
+	case requestHasMI && !requestHasUpdate && !details.MaintenanceInfoVersion.Equal(details.PreviousMaintenanceInfoVersion):
+		// add or change MI: MI changed and no updates, so must be an upgrade
+		return Upgrade, nil
+	case !requestHasMI && !planMaintenanceInfoVersion.Equal(details.PreviousMaintenanceInfoVersion):
+		// platform out of sync: No new MI, but previous MI and plan do not match, so platform out of sync with broker
+		return Failed, apiresponses.ErrMaintenanceInfoConflict
 	default:
-		// It's not a valid or invalid upgrade, so must be an update
+		// It's not an error or an Upgrade, so must be an Update
 		return Update, nil
 	}
 }

--- a/brokerapi/broker/decider/decider.go
+++ b/brokerapi/broker/decider/decider.go
@@ -20,29 +20,37 @@ const (
 const upgradeBeforeUpdateError = "service instance needs to be upgraded before updating"
 
 func DecideOperation(planMaintenanceInfoVersion *version.Version, details paramparser.UpdateDetails) (Operation, error) {
+	requestHasMI := details.MaintenanceInfoVersion != nil
+	requestHasPreviousMI := details.PreviousMaintenanceInfoVersion != nil
+
 	requestHasParams := len(details.RequestParams) != 0
 	requestHasPlanChange := details.PlanID != "" && details.PlanID != details.PreviousPlanID
 	requestHasUpdate := requestHasParams || requestHasPlanChange
 
-	requestHasMI := details.MaintenanceInfoVersion != nil
-	requestHasUpgrade := details.MaintenanceInfoVersion != nil && details.PreviousMaintenanceInfoVersion != nil && !details.MaintenanceInfoVersion.Equal(details.PreviousMaintenanceInfoVersion)
-	requestIntroducesMI := requestHasMI && details.PreviousMaintenanceInfoVersion == nil
-	requestRemovesMI := !requestHasMI && details.PreviousMaintenanceInfoVersion != nil
+	// There's an update, new and previous MI, and the new MI does not match the plan
+	invalidUpdateAndMIChange := requestHasUpdate && requestHasMI && requestHasPreviousMI && !details.MaintenanceInfoVersion.Equal(details.PreviousMaintenanceInfoVersion)
 
-	planAndRequestMIDiffer := requestHasMI && !details.MaintenanceInfoVersion.Equal(planMaintenanceInfoVersion)
+	// There's an update, new MI, no previous MI, and the new MI does not match the plan
+	invalidUpdateAndMIAddition := requestHasUpdate && requestHasMI && !requestHasPreviousMI && !details.MaintenanceInfoVersion.Equal(planMaintenanceInfoVersion)
+
+	// There's an update, no new MI, plan does not have MI, and there's a previous MI value
+	invalidUpdateAndMIRemoval := requestHasUpdate && !requestHasMI && requestHasPreviousMI && planMaintenanceInfoVersion == nil
 
 	switch {
-	case planAndRequestMIDiffer && planMaintenanceInfoVersion == nil:
+	case details.MaintenanceInfoVersion != nil && planMaintenanceInfoVersion == nil:
+		// new MI is specified in request, but plan does not have MI
 		return Failed, apiresponses.ErrMaintenanceInfoNilConflict
-	case planAndRequestMIDiffer:
+	case details.MaintenanceInfoVersion != nil && !planMaintenanceInfoVersion.Equal(details.MaintenanceInfoVersion):
+		// new MI is specified, and doesn't match the plan MI
 		return Failed, apiresponses.ErrMaintenanceInfoConflict
-	case requestHasUpdate && requestHasUpgrade:
+	case invalidUpdateAndMIChange, invalidUpdateAndMIAddition, invalidUpdateAndMIRemoval:
+		// invalid mixing of an update with an attempt to add, remove or alter MI
 		return Failed, errInstanceMustBeUpgradedFirst()
-	case requestHasUpdate:
-		return Update, nil
-	case requestHasUpgrade, requestIntroducesMI, requestRemovesMI:
+	case !requestHasUpdate && !details.MaintenanceInfoVersion.Equal(details.PreviousMaintenanceInfoVersion):
+		// MI changed and no updates, so must be an upgrade
 		return Upgrade, nil
 	default:
+		// It's not a valid or invalid upgrade, so must be an update
 		return Update, nil
 	}
 }

--- a/brokerapi/broker/decider/decider.go
+++ b/brokerapi/broker/decider/decider.go
@@ -19,6 +19,10 @@ const (
 
 const upgradeBeforeUpdateError = "service instance needs to be upgraded before updating"
 
+// DecideOperation works out whether the platform (typically CloudFoundry) is trying to perform an Update
+// of plan/parameters, or an Upgrade of Maintenance Info version. Is it an error to perform both at the
+// same time. CloudFoundry provides only the fields it intends to change in the request body,
+// but provides previous values for all fields. Where there is ambiguity, we rely on this CloudFoundry behavior.
 func DecideOperation(planMaintenanceInfoVersion *version.Version, details paramparser.UpdateDetails) (Operation, error) {
 	requestHasMI := details.MaintenanceInfoVersion != nil
 	requestHasPreviousMI := details.PreviousMaintenanceInfoVersion != nil
@@ -27,12 +31,15 @@ func DecideOperation(planMaintenanceInfoVersion *version.Version, details paramp
 	requestHasPlanChange := details.PlanID != "" && details.PlanID != details.PreviousPlanID
 	requestHasUpdate := requestHasParams || requestHasPlanChange
 
-	// There's an update, new and previous MI, and the new MI does not match the previous MI.
-	// So there's a definite attempt to upgrade and update at the same time.
-	invalidUpdateAndMIChange := requestHasUpdate && requestHasMI && requestHasPreviousMI && !details.MaintenanceInfoVersion.Equal(details.PreviousMaintenanceInfoVersion)
+	// There's an update to plan/parameters, new MI, and the new MI does not match the previous MI.
+	// So it's an attempt to upgrade and update at the same time.
+	invalidUpdateAndMIChange := requestHasUpdate && requestHasMI && !details.MaintenanceInfoVersion.Equal(details.PreviousMaintenanceInfoVersion)
 
-	// There's an update, no new MI, plan does not have MI, but there's a previous MI value, so
-	// it looks like we are trying to change version at the same time as an update
+	// There's an update to plan/parameters, no new MI, plan does not have MI, but there's a previous MI value, so
+	// it looks like we are trying to change version (to having no MI) at the same time as an update.
+	// Valid options would be:
+	// - update to plan/parameters with previous MI the same as plan MI
+	// - upgrade to the no-MI plan with no updates of plan/parameters
 	invalidUpdateAndMIRemoval := requestHasUpdate && !requestHasMI && requestHasPreviousMI && planMaintenanceInfoVersion == nil
 
 	switch {
@@ -43,7 +50,7 @@ func DecideOperation(planMaintenanceInfoVersion *version.Version, details paramp
 		// new MI is specified, and doesn't match the plan MI
 		return Failed, apiresponses.ErrMaintenanceInfoConflict
 	case invalidUpdateAndMIChange, invalidUpdateAndMIRemoval:
-		// invalid mixing of an update with an attempt to change or remove MI
+		// invalid mixing of an update with an attempt to change MI
 		return Failed, errInstanceMustBeUpgradedFirst()
 	case !requestHasUpdate && !details.MaintenanceInfoVersion.Equal(details.PreviousMaintenanceInfoVersion):
 		// MI changed and no updates, so must be an upgrade

--- a/brokerapi/broker/decider/decider_test.go
+++ b/brokerapi/broker/decider/decider_test.go
@@ -23,15 +23,15 @@ var _ = DescribeTable(
 		)
 		for _, token := range separator.Split(spec, -1) {
 			switch token {
-			case "no MI in plan", "no params", "no request MI":
+			case "service has no MI", "no params", "no request MI":
 			case "plan change":
 				details.PlanID = "new-plan-id"
 				details.PreviousPlanID = "previous-plan-id"
 			case "plan unchanged":
 				details.PreviousPlanID = "plan-id"
-			case "plan at v1":
+			case "service at v1":
 				planVersion = version.Must(version.NewVersion("1.0.0"))
-			case "plan at v2":
+			case "service at v2":
 				planVersion = version.Must(version.NewVersion("2.0.0"))
 			case "params":
 				details.RequestParams = map[string]any{"foo": "bar"}
@@ -62,52 +62,52 @@ var _ = DescribeTable(
 		Expect(operation).To(Equal(expectedOperation))
 	},
 	// Old world Updates - MI does not exist
-	Entry(nil, "no MI in plan; no request MI; plan unchanged; no params", decider.Update, nil),
-	Entry(nil, "no MI in plan; no request MI; plan change;    no params", decider.Update, nil),
-	Entry(nil, "no MI in plan; no request MI; plan unchanged; params", decider.Update, nil),
-	Entry(nil, "no MI in plan; no request MI; plan change;    params", decider.Update, nil),
+	Entry(nil, "service has no MI; no request MI; plan unchanged; no params", decider.Update, nil),
+	Entry(nil, "service has no MI; no request MI; plan change;    no params", decider.Update, nil),
+	Entry(nil, "service has no MI; no request MI; plan unchanged; params", decider.Update, nil),
+	Entry(nil, "service has no MI; no request MI; plan change;    params", decider.Update, nil),
 
 	// New world Updates, MI is in previous values and is not being changed
-	Entry(nil, "plan at v1; MI unchanged; plan change;    no params", decider.Update, nil),
-	Entry(nil, "plan at v1; MI unchanged; plan unchanged; params", decider.Update, nil),
-	Entry(nil, "plan at v1; MI unchanged; plan change;    params", decider.Update, nil),
+	Entry(nil, "service at v1; MI unchanged; plan change;    no params", decider.Update, nil),
+	Entry(nil, "service at v1; MI unchanged; plan unchanged; params", decider.Update, nil),
+	Entry(nil, "service at v1; MI unchanged; plan change;    params", decider.Update, nil),
 
 	// Adding, removing and changing MI
-	Entry(nil, "plan at v1;    MI none->v1;  plan unchanged; no params", decider.Upgrade, nil),
-	Entry(nil, "no MI in plan; MI v1->none;  plan unchanged; no params", decider.Upgrade, nil),
-	Entry(nil, "plan at v1;    MI v2->v1;    plan unchanged; no params", decider.Upgrade, nil),
+	Entry(nil, "service at v1;     MI none->v1;  plan unchanged; no params", decider.Upgrade, nil),
+	Entry(nil, "service has no MI; MI v1->none;  plan unchanged; no params", decider.Upgrade, nil),
+	Entry(nil, "service at v1;     MI v2->v1;    plan unchanged; no params", decider.Upgrade, nil),
 
 	// Combined Upgrade and Update
-	Entry(nil, "plan at v1;    MI v2->v1;   plan unchanged; params", decider.Failed, "service instance needs to be upgraded before updating"),
-	Entry(nil, "plan at v1;    MI v2->v1;   plan change;    no params", decider.Failed, "service instance needs to be upgraded before updating"),
-	Entry(nil, "plan at v1;    MI v2->v1;   plan change;    params", decider.Failed, "service instance needs to be upgraded before updating"),
-	Entry(nil, "no MI in plan; MI v1->none; plan change;    no params", decider.Failed, "service instance needs to be upgraded before updating"),
-	Entry(nil, "no MI in plan; MI v1->none; plan unchanged; params", decider.Failed, "service instance needs to be upgraded before updating"),
-	Entry(nil, "no MI in plan; MI v1->none; plan change;    params", decider.Failed, "service instance needs to be upgraded before updating"),
-	Entry(nil, "plan at v1;    MI none->v1; plan change;    no params", decider.Failed, "service instance needs to be upgraded before updating"),
-	Entry(nil, "plan at v1;    MI none->v1; plan unchanged; params", decider.Failed, "service instance needs to be upgraded before updating"),
-	Entry(nil, "plan at v1;    MI none->v1; plan change;    params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "service at v1;     MI v2->v1;   plan unchanged; params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "service at v1;     MI v2->v1;   plan change;    no params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "service at v1;     MI v2->v1;   plan change;    params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "service has no MI; MI v1->none; plan change;    no params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "service has no MI; MI v1->none; plan unchanged; params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "service has no MI; MI v1->none; plan change;    params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "service at v1;     MI none->v1; plan change;    no params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "service at v1;     MI none->v1; plan unchanged; params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "service at v1;     MI none->v1; plan change;    params", decider.Failed, "service instance needs to be upgraded before updating"),
 
 	// Attempted upgrades where the requested MI does not match the plan MI
-	Entry(nil, "plan at v1;    MI none->v2; plan unchanged; no params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
-	Entry(nil, "no MI in plan; MI none->v1; plan unchanged; no params", decider.Failed, apiresponses.ErrMaintenanceInfoNilConflict),
+	Entry(nil, "service at v1;     MI none->v2; plan unchanged; no params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
+	Entry(nil, "service has no MI; MI none->v1; plan unchanged; no params", decider.Failed, apiresponses.ErrMaintenanceInfoNilConflict),
 
 	// Updates where MI is held constant
 	// In this case the Upgrade would be a no-op, so we default to it being a valid Update
-	Entry(nil, "plan at v1; MI v1->v1; plan unchanged; no params", decider.Update, nil),
-	Entry(nil, "plan at v1; MI v1->v1; plan change;    no params", decider.Update, nil),
-	Entry(nil, "plan at v1; MI v1->v1; plan unchanged; params", decider.Update, nil),
-	Entry(nil, "plan at v1; MI v1->v1; plan change;    params", decider.Update, nil),
+	Entry(nil, "service at v1; MI v1->v1; plan unchanged; no params", decider.Update, nil),
+	Entry(nil, "service at v1; MI v1->v1; plan change;    no params", decider.Update, nil),
+	Entry(nil, "service at v1; MI v1->v1; plan unchanged; params", decider.Update, nil),
+	Entry(nil, "service at v1; MI v1->v1; plan change;    params", decider.Update, nil),
 
 	// When previous MI does not match the plan, and it's not an upgrade, it suggests the platform
 	// (typically CloudFoundry) is not in sync with the broker. With CloudFoundry the "cf update-service-broker"
 	// command needs to be run
-	Entry(nil, "plan at v2; MI unchanged;  plan unchanged; no params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
-	Entry(nil, "plan at v2; MI unchanged;  plan change;    no params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
-	Entry(nil, "plan at v2; MI unchanged;  plan unchanged; params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
-	Entry(nil, "plan at v2; MI unchanged;  plan change;    params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
-	Entry(nil, "plan at v1; no request MI; plan unchanged; no params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
-	Entry(nil, "plan at v1; no request MI; plan change;    no params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
-	Entry(nil, "plan at v1; no request MI; plan unchanged; params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
-	Entry(nil, "plan at v1; no request MI; plan change;    params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
+	Entry(nil, "service at v2; MI unchanged;  plan unchanged; no params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
+	Entry(nil, "service at v2; MI unchanged;  plan change;    no params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
+	Entry(nil, "service at v2; MI unchanged;  plan unchanged; params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
+	Entry(nil, "service at v2; MI unchanged;  plan change;    params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
+	Entry(nil, "service at v1; no request MI; plan unchanged; no params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
+	Entry(nil, "service at v1; no request MI; plan change;    no params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
+	Entry(nil, "service at v1; no request MI; plan unchanged; params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
+	Entry(nil, "service at v1; no request MI; plan change;    params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
 )

--- a/brokerapi/broker/decider/decider_test.go
+++ b/brokerapi/broker/decider/decider_test.go
@@ -76,31 +76,35 @@ var _ = DescribeTable(
 	Entry(nil, "plan at v1;    MI v2->v1;    plan unchanged; no params", decider.Upgrade, nil),
 
 	// Combined Upgrade and Update
-	Entry(nil, "plan at v1; MI v2->v1; plan unchanged; params", decider.Failed, "service instance needs to be upgraded before updating"),
-	Entry(nil, "plan at v1; MI v2->v1; plan change;    no params", decider.Failed, "service instance needs to be upgraded before updating"),
-	Entry(nil, "plan at v1; MI v2->v1; plan change;    params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "plan at v1;    MI v2->v1;   plan unchanged; params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "plan at v1;    MI v2->v1;   plan change;    no params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "plan at v1;    MI v2->v1;   plan change;    params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "no MI in plan; MI v1->none; plan change;    no params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "no MI in plan; MI v1->none; plan unchanged; params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "no MI in plan; MI v1->none; plan change;    params", decider.Failed, "service instance needs to be upgraded before updating"),
 
 	// Attempted upgrades where the requested MI does not match the plan MI
 	Entry(nil, "plan at v1;    MI none->v2; plan unchanged; no params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
 	Entry(nil, "no MI in plan; MI none->v1; plan unchanged; no params", decider.Failed, apiresponses.ErrMaintenanceInfoNilConflict),
 
-	// Updates where MI is held constant
+	// Edge case: updates where MI is held constant
 	// With CloudFoundry, new MI is only specified if it's different to previous MI, so we do not see this.
 	Entry(nil, "plan at v1; MI v1->v1; plan unchanged; no params", decider.Update, nil),
 	Entry(nil, "plan at v1; MI v1->v1; plan change;    no params", decider.Update, nil),
 	Entry(nil, "plan at v1; MI v1->v1; plan unchanged; params", decider.Update, nil),
 	Entry(nil, "plan at v1; MI v1->v1; plan change;    params", decider.Update, nil),
 
-	// Updates where MI is not specified at all in the request as it has not changed.
+	// Edge case: updates where MI is not specified at all in the request as it has not changed.
 	// With CloudFoundry, previous MI is always specified, so we do not see this.
 	Entry(nil, "plan at v1; no request MI; plan unchanged; no params", decider.Update, nil),
 	Entry(nil, "plan at v1; no request MI; plan change;    no params", decider.Update, nil),
 	Entry(nil, "plan at v1; no request MI; plan unchanged; params", decider.Update, nil),
 	Entry(nil, "plan at v1; no request MI; plan change;    params", decider.Update, nil),
 
-	// When previous MI is nil, and there are other changes, it's an Update because the
-	// lack of a "previous MI" means the MI has not changed. With CloudFoundry, the previous
-	// MI is always specified, so we do not see this.
+	// Edge case: when there's no previous MI, but the new MI matches the plan MI,
+	// we assume it's an update if there are updates, otherwise it's an upgrade.
+	// With CloudFoundry, the previous MI is always specified, so we do not see this.
+	Entry(nil, "plan at v1; MI none->v1;  plan unchanged; no params", decider.Upgrade, nil),
 	Entry(nil, "plan at v1; MI none->v1;  plan change; no params", decider.Update, nil),
 	Entry(nil, "plan at v1; MI none->v1;  plan unchanged; params", decider.Update, nil),
 	Entry(nil, "plan at v1; MI none->v1;  plan change; params", decider.Update, nil),

--- a/brokerapi/broker/decider/decider_test.go
+++ b/brokerapi/broker/decider/decider_test.go
@@ -82,6 +82,9 @@ var _ = DescribeTable(
 	Entry(nil, "no MI in plan; MI v1->none; plan change;    no params", decider.Failed, "service instance needs to be upgraded before updating"),
 	Entry(nil, "no MI in plan; MI v1->none; plan unchanged; params", decider.Failed, "service instance needs to be upgraded before updating"),
 	Entry(nil, "no MI in plan; MI v1->none; plan change;    params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "plan at v1;    MI none->v1; plan change;    no params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "plan at v1;    MI none->v1; plan unchanged; params", decider.Failed, "service instance needs to be upgraded before updating"),
+	Entry(nil, "plan at v1;    MI none->v1; plan change;    params", decider.Failed, "service instance needs to be upgraded before updating"),
 
 	// Attempted upgrades where the requested MI does not match the plan MI
 	Entry(nil, "plan at v1;    MI none->v2; plan unchanged; no params", decider.Failed, apiresponses.ErrMaintenanceInfoConflict),
@@ -100,12 +103,4 @@ var _ = DescribeTable(
 	Entry(nil, "plan at v1; no request MI; plan change;    no params", decider.Update, nil),
 	Entry(nil, "plan at v1; no request MI; plan unchanged; params", decider.Update, nil),
 	Entry(nil, "plan at v1; no request MI; plan change;    params", decider.Update, nil),
-
-	// Edge case: when there's no previous MI, but the new MI matches the plan MI,
-	// we assume it's an update if there are updates, otherwise it's an upgrade.
-	// With CloudFoundry, the previous MI is always specified, so we do not see this.
-	Entry(nil, "plan at v1; MI none->v1;  plan unchanged; no params", decider.Upgrade, nil),
-	Entry(nil, "plan at v1; MI none->v1;  plan change; no params", decider.Update, nil),
-	Entry(nil, "plan at v1; MI none->v1;  plan unchanged; params", decider.Update, nil),
-	Entry(nil, "plan at v1; MI none->v1;  plan change; params", decider.Update, nil),
 )

--- a/brokerapi/broker/update.go
+++ b/brokerapi/broker/update.go
@@ -60,7 +60,7 @@ func (broker *ServiceBroker) Update(ctx context.Context, instanceID string, deta
 	if err != nil {
 		return domain.UpdateServiceSpec{}, err
 	}
-	maintenanceInfoVersion, err := planMaintenanceInfoVersion(plan)
+	maintenanceInfoVersion, err := readMaintenanceInfoVersion(plan)
 	if err != nil {
 		return domain.UpdateServiceSpec{}, err
 	}
@@ -197,7 +197,7 @@ func mergeJSON(previousParams, newParams, importParams map[string]interface{}) (
 	return vc.ToMap(), nil
 }
 
-func planMaintenanceInfoVersion(plan *broker.ServicePlan) (*version.Version, error) {
+func readMaintenanceInfoVersion(plan *broker.ServicePlan) (*version.Version, error) {
 	if plan.MaintenanceInfo != nil && len(plan.MaintenanceInfo.Version) != 0 {
 		maintenanceInfoVersion, err := version.NewVersion(plan.MaintenanceInfo.Version)
 		if err != nil {

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -33,5 +33,6 @@
 - brokerpaktestframework.TerraformMock.ReturnTFState() has been superseded by to SetTFState(). The original method works but is deprecated. The goal of this change is to be more precise in terms of the functionality of the method.
 - Broker fails to delete service when create is in progress.
 - Fixes concatenation of words in Terraform error messages
+- Fixes an issue where a service instance update was incorrectly classified as invalid
 
 

--- a/integrationtest/fixtures/terraform-upgrade-updated/fake-service.yml
+++ b/integrationtest/fixtures/terraform-upgrade-updated/fake-service.yml
@@ -14,6 +14,10 @@ plans:
 provision:
   template_refs:
     main: fake-provision.tf
+  user_inputs:
+    - field_name: alpha_input
+      type: string
+      details: alpha input
   outputs:
       - field_name: provision_output
         type: integer

--- a/integrationtest/fixtures/terraform-upgrade/fake-service.yml
+++ b/integrationtest/fixtures/terraform-upgrade/fake-service.yml
@@ -14,6 +14,10 @@ plans:
 provision:
   template_refs:
     main: fake-provision.tf
+  user_inputs:
+    - field_name: alpha_input
+      type: string
+      details: alpha input
   outputs:
     - field_name: provision_output
       type: integer

--- a/integrationtest/multiple_update_properties_test.go
+++ b/integrationtest/multiple_update_properties_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Multiple Updates to Properties", func() {
 	BeforeEach(func() {
 		testHelper = helper.New(csb)
 		testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "multiple-update-properties")
-		session = testHelper.StartBroker()
+		session = testHelper.StartBroker("TERRAFORM_UPGRADES_ENABLED=true")
 	})
 
 	AfterEach(func() {

--- a/integrationtest/multiple_update_properties_test.go
+++ b/integrationtest/multiple_update_properties_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Multiple Updates to Properties", func() {
 	BeforeEach(func() {
 		testHelper = helper.New(csb)
 		testHelper.BuildBrokerpak(testHelper.OriginalDir, "fixtures", "multiple-update-properties")
-		session = testHelper.StartBroker("TERRAFORM_UPGRADES_ENABLED=true")
+		session = testHelper.StartBroker()
 	})
 
 	AfterEach(func() {

--- a/integrationtest/terraform_rename_provider_test.go
+++ b/integrationtest/terraform_rename_provider_test.go
@@ -33,7 +33,14 @@ var _ = Describe("Terraform Rename Provider", func() {
 		session = testHelper.StartBroker("TERRAFORM_UPGRADES_ENABLED=true", "BROKERPAK_UPDATES_ENABLED=true")
 
 		By("running 'cf update-service'")
-		testHelper.UpgradeService(serviceInstance, domain.PreviousValues{PlanID: servicePlanGUID}, domain.MaintenanceInfo{Version: "0.13.7"}, `{"alpha_input":"quz"}`)
+		testHelper.UpgradeService(
+			serviceInstance,
+			domain.PreviousValues{
+				PlanID:          servicePlanGUID,
+				MaintenanceInfo: &domain.MaintenanceInfo{Version: "0.13.7"},
+			},
+			domain.MaintenanceInfo{Version: "0.13.7"}, `{"alpha_input":"quz"}`,
+		)
 	})
 
 	It("can delete instance when provider is renamed", func() {

--- a/integrationtest/terraform_upgrade_test.go
+++ b/integrationtest/terraform_upgrade_test.go
@@ -112,6 +112,9 @@ var _ = Describe("Terraform Upgrade", func() {
 			By("observing that the binding TF state file has updated output value")
 			Expect(bindingTerraformStateOutputValue(serviceInstance.GUID, firstBindGUID)).To(BeElementOf(3, 4))
 			Expect(bindingTerraformStateOutputValue(serviceInstance.GUID, secondBindGUID)).To(BeElementOf(3, 4))
+
+			By("updating the service after the upgrade")
+			testHelper.UpdateService(serviceInstance, `{"alpha_input":"foo"}`)
 		})
 	})
 

--- a/integrationtest/terraform_upgrade_test.go
+++ b/integrationtest/terraform_upgrade_test.go
@@ -114,7 +114,9 @@ var _ = Describe("Terraform Upgrade", func() {
 			Expect(bindingTerraformStateOutputValue(serviceInstance.GUID, secondBindGUID)).To(BeElementOf(3, 4))
 
 			By("updating the service after the upgrade")
-			testHelper.UpdateService(serviceInstance, `{"alpha_input":"foo"}`)
+			testHelper.UpdateService(serviceInstance, `{"alpha_input":"foo"}`, domain.PreviousValues{
+				MaintenanceInfo: &domain.MaintenanceInfo{Version: endingVersion},
+			})
 		})
 	})
 


### PR DESCRIPTION
Once a service instance has been upgraded, Cloud Foundry will put the
service instance's current Maintenance Info into the "previous values"
section of an update request. There's a relatively subtle
differentiation between:
- Downgrading a service instance (where it currently has a maintenance
info version and this is being removed), which is an Upgrade
- Updating a service instance (where there's a previous Maintenance Info
value, and no new Maintenance Info value) where there are other updates

The previous algorithm was hard to reason about, so it has been
redeveloped by adding many more table tests to solidify the behaviour.

As a general rule, Cloud Foundry provides a "previous values" block
which has all the current values, and only provides a new value when it
changes.

[#182522081](https://www.pivotaltracker.com/story/show/182522081)

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

