### PR TITLE
fix: brokerpaktestframework fails with "terraform_upgrade_path"

### DIFF
--- a/brokerpaktestframework/broker_pack_path_finder.go
+++ b/brokerpaktestframework/broker_pack_path_finder.go
@@ -5,8 +5,16 @@ import (
 	"runtime"
 )
 
-func PathToBrokerPack() string {
-	_, file, _, _ := runtime.Caller(1)
+func PathToBrokerPack(skips ...int) string {
+	skip := 1
+	switch len(skips) {
+	case 0:
+	case 1:
+		skip += skips[0]
+	default:
+		panic("too many skips")
+	}
+	_, file, _, _ := runtime.Caller(skip)
 
 	return filepath.Dir(filepath.Dir(file))
 }

--- a/brokerpaktestframework/osbapi_helper.go
+++ b/brokerpaktestframework/osbapi_helper.go
@@ -1,6 +1,8 @@
 package brokerpaktestframework
 
 import (
+	"fmt"
+
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 	"github.com/pivotal-cf/brokerapi/v8/domain/apiresponses"
 )
@@ -27,12 +29,12 @@ func FindServicePlan(catalog *apiresponses.CatalogResponse, serviceName, service
 	return domain.ServicePlan{}
 }
 
-func FindServicePlanGUIDs(catalog *apiresponses.CatalogResponse, serviceName, planName string) (string, string) {
+func FindServicePlanGUIDs(catalog *apiresponses.CatalogResponse, serviceName, planName string) (string, string, error) {
 	service := FindService(catalog, serviceName)
 	for _, plan := range service.Plans {
 		if plan.Name == planName {
-			return service.ID, plan.ID
+			return service.ID, plan.ID, nil
 		}
 	}
-	return "", ""
+	return "", "", fmt.Errorf("cannot find service %q and plan %q in catalog", serviceName, planName)
 }

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -37,5 +37,6 @@
 - Broker fails to delete service when create is in progress.
 - Fixes concatenation of words in Terraform error messages
 - Fixes an issue where a service instance update was incorrectly classified as invalid
+- brokerpaktestfrawork now handles "terraform_upgrade_path", as part of this change the signature for `FindServicePlanGUIDs()` was changed to return an error as errors were previously silent
 
 

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -37,6 +37,6 @@
 - Broker fails to delete service when create is in progress.
 - Fixes concatenation of words in Terraform error messages
 - Fixes an issue where a service instance update was incorrectly classified as invalid
-- brokerpaktestfrawork now handles "terraform_upgrade_path", as part of this change the signature for `FindServicePlanGUIDs()` was changed to return an error as errors were previously silent
+- brokerpaktestframework now handles "terraform_upgrade_path", as part of this change the signature for `FindServicePlanGUIDs()` was changed to return an error as errors were previously silent
 
 

--- a/integrationtest/brokerpaktestframework_test.go
+++ b/integrationtest/brokerpaktestframework_test.go
@@ -1,0 +1,56 @@
+package integrationtest
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/cloudfoundry/cloud-service-broker/brokerpaktestframework"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("brokerpaktestframework", func() {
+	It("works", func() {
+		By("creating a mock Terraform")
+		mockTerraform, err := brokerpaktestframework.NewTerraformMock(brokerpaktestframework.WithVersion("1.2.3"))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("building a fake brokerpak")
+		cwd, err := os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+		broker, err := brokerpaktestframework.BuildTestInstance(
+			filepath.Join(cwd, "fixtures", "brokerpaktestframework"),
+			mockTerraform,
+			GinkgoWriter,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("starting the broker")
+		Expect(broker.Start(GinkgoWriter, nil)).To(Succeed())
+
+		By("testing catalog")
+		catalog, err := broker.Catalog()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(catalog.Services).To(HaveLen(1))
+		Expect(catalog.Services[0].Name).To(Equal("alpha-service"))
+
+		By("testing provision")
+		_, err = broker.Provision("does-not-exist", "does-not-exist", nil)
+		Expect(err).To(MatchError(`cannot find service "does-not-exist" and plan "does-not-exist" in catalog`))
+		serviceInstanceID, err := broker.Provision("alpha-service", "alpha", nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serviceInstanceID).To(HaveLen(36))
+
+		By("testing bind")
+		_, err = broker.Bind("does-not-exist", "does-not-exist", "does-not-exist", nil)
+		Expect(err).To(MatchError(`cannot find service "does-not-exist" and plan "does-not-exist" in catalog`))
+		_, err = broker.Bind("alpha-service", "alpha", "does-not-exist", nil)
+		Expect(err).To(MatchError(ContainSubstring(`error retrieving service instance details: could not find service instance details for: does-not-exist`)))
+		creds, err := broker.Bind("alpha-service", "alpha", serviceInstanceID, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(creds).To(BeEmpty())
+
+		By("stopping the broker")
+		Expect(broker.Cleanup()).To(Succeed())
+	})
+})

--- a/integrationtest/fixtures/brokerpaktestframework/fake-service.yml
+++ b/integrationtest/fixtures/brokerpaktestframework/fake-service.yml
@@ -1,0 +1,14 @@
+version: 1
+name: alpha-service
+
+id: 76c5725c-b246-11eb-871f-ffc97563fbd0
+description: description
+display_name: Alpha Service
+image_url: https://example.com/icon.jpg
+documentation_url: https://example.com
+support_url: https://example.com/support.html
+plans:
+- name: alpha
+  id: 8b52a460-b246-11eb-a8f5-d349948e2480
+  description: Alpha plan
+  display_name: Alpha

--- a/integrationtest/fixtures/brokerpaktestframework/manifest.yml
+++ b/integrationtest/fixtures/brokerpaktestframework/manifest.yml
@@ -1,0 +1,21 @@
+packversion: 1
+name: fake-brokerpak
+version: 0.1.0
+metadata:
+  author: noone@nowhere.com
+platforms:
+- os: linux
+  arch: amd64
+- os: darwin
+  arch: amd64
+terraform_binaries:
+- name: terraform
+  version: 0.12.21
+- name: terraform
+  version: 1.2.3
+  default: true
+terraform_upgrade_path:
+  - version: 0.12.21
+  - version: 1.2.3
+service_definitions:
+  - fake-service.yml


### PR DESCRIPTION
The brokerpaktestframwork failed if a "terraform_upgrade_path" was
specified. This is because the framework used to update the manifest to
have a single version of Terraform at 1.1.4. But when other versions are
specified in the "terraform_upgrade_path" then the manifest validation
fails.

- The brokerpaktestframework now reads the Terraform versions present in
the brokerpak and fakes them all (with the default version)
- There is a test for the brokerpaktestframework which will hopefully
find some of the worst errors in future
- The signature of `FindServicePlanGUIDs()` has been changed to return
an error rather than fail silentlu
- The fake broker is now started on a random port so that it does not
interfere with any locally running CSB instances
- If building the fake brokerpak fails, an error is returned

[#181155154](https://www.pivotaltracker.com/story/show/181155154)

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

