### PR TITLE
fix: add state-replace command before TF show

### DIFF
--- a/pkg/providers/tf/invoker/terraform_default_invoker.go
+++ b/pkg/providers/tf/invoker/terraform_default_invoker.go
@@ -32,8 +32,11 @@ func (cmd TerraformDefaultInvoker) Apply(ctx context.Context, workspace workspac
 
 func (cmd TerraformDefaultInvoker) Show(ctx context.Context, workspace workspace.Workspace) (string, error) {
 	output, err := workspace.Execute(ctx, cmd.executor,
-		command.NewInit(cmd.pluginDirectory),
-		command.NewShow())
+		append(
+			cmd.ReplacementCommands(),
+			command.NewInit(cmd.pluginDirectory),
+			command.NewShow(),
+		)...)
 	return output.StdOut, err
 }
 

--- a/pkg/providers/tf/invoker/terraform_default_invoker_test.go
+++ b/pkg/providers/tf/invoker/terraform_default_invoker_test.go
@@ -100,4 +100,39 @@ var _ = Context("TerraformDefaultInvoker", func() {
 			})
 		})
 	})
+
+	Context("Show", func() {
+		Context("has no renames", func() {
+			BeforeEach(func() {
+				invokerUnderTest = invoker.NewTerraformDefaultInvoker(fakeExecutor, pluginDirectory, nil)
+			})
+			It("initializes the workspace and show", func() {
+				invokerUnderTest.Show(expectedContext, fakeWorkspace)
+
+				Expect(fakeWorkspace.ExecuteCallCount()).To(Equal(1))
+				actualContext, actualExecutor, actualCommands := fakeWorkspace.ExecuteArgsForCall(0)
+				Expect(actualContext).To(Equal(expectedContext))
+				Expect(actualExecutor).To(Equal(fakeExecutor))
+				Expect(actualCommands).To(Equal([]command.TerraformCommand{
+					command.NewInit(pluginDirectory),
+					command.NewShow(),
+				}))
+			})
+		})
+		Context("has renames", func() {
+			It("renames providers before, initializing the workspace and applies", func() {
+				invokerUnderTest.Show(expectedContext, fakeWorkspace)
+
+				Expect(fakeWorkspace.ExecuteCallCount()).To(Equal(1))
+				actualContext, actualExecutor, actualCommands := fakeWorkspace.ExecuteArgsForCall(0)
+				Expect(actualContext).To(Equal(expectedContext))
+				Expect(actualExecutor).To(Equal(fakeExecutor))
+				Expect(actualCommands).To(Equal([]command.TerraformCommand{
+					command.NewRenameProvider("old_provider_1", "new_provider_1"),
+					command.NewInit(pluginDirectory),
+					command.NewShow(),
+				}))
+			})
+		})
+	})
 })


### PR DESCRIPTION
In the update flow we call GetImportedProperties(), this method
invokes TF show. When the HCL has been updated to a later version of TF,
but the state has not yet been upgraded this errored. To mitigate this,
we need to perform a state-replace-provider action before running show.

### Checklist:

* [ ] Have you added or updated tests to validate the changed functionality?
~~* [ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

