### PR TITLE
fix: handle new "terraform show" output

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -40,5 +40,6 @@
 - Fixes concatenation of words in Terraform error messages
 - Fixes an issue where a service instance update was incorrectly classified as invalid
 - brokerpaktestframework now handles "terraform_upgrade_path", as part of this change the signature for `FindServicePlanGUIDs()` was changed to return an error as errors were previously silent
+- "terraform show" output for Terraform greater than 0.12 is how handled correctly
 
 

--- a/pkg/providers/tf/provision.go
+++ b/pkg/providers/tf/provision.go
@@ -3,6 +3,7 @@ package tf
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cloudfoundry/cloud-service-broker/pkg/broker"
 
@@ -170,6 +171,10 @@ func evaluateParametersToAdd(importParametersToAdd []ImportParameterMapping) []w
 }
 
 func createTFMainDefinition(workspace *workspace.TerraformWorkspace, mainTf string, logger lager.Logger) error {
+	if i := strings.Index(mainTf, "\nOutputs:"); i >= 0 {
+		mainTf = mainTf[:i]
+	}
+
 	var tf string
 	var parameterVals map[string]string
 	tf, parameterVals, err := workspace.Transformer.ReplaceParametersInTf(workspace.Transformer.AddParametersInTf(workspace.Transformer.CleanTf(mainTf)))


### PR DESCRIPTION
The command "terraform show" is used in the subsume process, and in
versions of Terraform higher than 0.12 it sometimes has additional
output starting with "Outputs:". This fix removes that additional text so that
subsume continues to function as before.

The need for this kind of fix highlights the fragility of subsume.

[#182571088](https://www.pivotaltracker.com/story/show/182571088)

### Checklist:

* ~~[ ] Have you added or updated tests to validate the changed functionality?~~ this is tested in brokerpak integration tests
* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

