### PR TITLE
feat: revert "feat: remove brokerpak duplication with local brokerpak (#561)"

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -18,7 +18,6 @@
 - The `tf list` subcommand now prints the version of Terraform for each workspace state
 - A new "purge" subcommand can be used to remove a service instance from the database
 - brokerpaktestframework: extra folders needed for brokerpak build are now supported.
-- A duplicate copy of the brokerpak no longer occurs, freeing up disk space
 
 ### Fixes:
 - Broker checks the database deployment workspace readability aat startup before attempting encryption or removing salt.

--- a/internal/brokerpak/fetcher/fetch.go
+++ b/internal/brokerpak/fetcher/fetch.go
@@ -3,11 +3,28 @@
 package fetcher
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/hashicorp/go-getter"
 )
 
 func FetchArchive(src, dest string) error {
 	return newFileGetterClient(src, dest).Get()
+}
+
+func FetchBrokerpak(src, dest string) error {
+	execWd := filepath.Dir(os.Args[0])
+	execDir, err := filepath.Abs(execWd)
+	if err != nil {
+		return fmt.Errorf("couldn't turn dir %q into abs path: %v", execWd, err)
+	}
+
+	client := newFileGetterClient(src, dest)
+	client.Pwd = execDir
+
+	return client.Get()
 }
 
 func newFileGetterClient(src, dest string) *getter.Client {

--- a/internal/brokerpak/reader/reader.go
+++ b/internal/brokerpak/reader/reader.go
@@ -18,14 +18,17 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf"
+
+	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/fetcher"
 	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/manifest"
 	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/platform"
 	"github.com/cloudfoundry/cloud-service-broker/internal/zippy"
-	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf"
 	"github.com/cloudfoundry/cloud-service-broker/utils/stream"
 	"github.com/hashicorp/go-version"
 )
@@ -39,6 +42,24 @@ func OpenBrokerPak(pakPath string) (*BrokerPakReader, error) {
 		return nil, err
 	}
 	return &BrokerPakReader{contents: rc}, nil
+}
+
+// DownloadAndOpenBrokerpak downloads a (potentially remote) brokerpak to
+// the local filesystem and opens it.
+func DownloadAndOpenBrokerpak(pakURI string) (*BrokerPakReader, error) {
+	// create a temp directory to hold the pak
+	pakDir, err := os.MkdirTemp("", "brokerpak-staging")
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create brokerpak staging area for %q: %v", pakURI, err)
+	}
+
+	// Download the brokerpak
+	localLocation := filepath.Join(pakDir, "pack.brokerpak")
+	if err := fetcher.FetchBrokerpak(pakURI, localLocation); err != nil {
+		return nil, fmt.Errorf("couldn't download brokerpak %q: %v", pakURI, err)
+	}
+
+	return OpenBrokerPak(localLocation)
 }
 
 // BrokerPakReader reads bundled together Terraform and service definitions.

--- a/pkg/brokerpak/config.go
+++ b/pkg/brokerpak/config.go
@@ -17,6 +17,7 @@ package brokerpak
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -159,6 +160,7 @@ func ListBrokerpaks(directory string) ([]string, error) {
 		if err != nil {
 			return err
 		}
+		log.Printf("examining file %v", path)
 		if filepath.Ext(path) == ".brokerpak" {
 			path, err := filepath.Abs(path)
 			if err != nil {

--- a/pkg/brokerpak/registrar.go
+++ b/pkg/brokerpak/registrar.go
@@ -58,7 +58,7 @@ func (r *Registrar) Register(registry broker.BrokerRegistry) error {
 			"prefix":            pak.ServicePrefix,
 		})
 
-		brokerPak, err := reader.OpenBrokerPak(pak.BrokerpakURI)
+		brokerPak, err := reader.DownloadAndOpenBrokerpak(pak.BrokerpakURI)
 		if err != nil {
 			return fmt.Errorf("couldn't open brokerpak: %q: %v", pak.BrokerpakURI, err)
 		}


### PR DESCRIPTION
This reverts commit 1caba305249371a318822b0990548725bd4b63e3.

@FelisiaM pointed out that remote brokerpaks are still possible to
configure via `brokerpak.sources` in the config file, so someone may
still be using remote brokerpaks.

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

