### PR TITLE
chore: remove brokerpak duplication with local brokerpak

### DIFF
--- a/internal/brokerpak/reader/reader.go
+++ b/internal/brokerpak/reader/reader.go
@@ -47,6 +47,10 @@ func OpenBrokerPak(pakPath string) (*BrokerPakReader, error) {
 // DownloadAndOpenBrokerpak downloads a (potentially remote) brokerpak to
 // the local filesystem and opens it.
 func DownloadAndOpenBrokerpak(pakURI string) (*BrokerPakReader, error) {
+	if isLocalFile(pakURI) {
+		return OpenBrokerPak(pakURI)
+	}
+
 	// create a temp directory to hold the pak
 	pakDir, err := os.MkdirTemp("", "brokerpak-staging")
 	if err != nil {
@@ -279,4 +283,9 @@ func providerInstallPath(terraformVersion *version.Version, destination string, 
 		tfProvider.Version.String(),
 		fmt.Sprintf("%s_%s", plat.Os, plat.Arch),
 	)
+}
+
+func isLocalFile(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }

--- a/pkg/brokerpak/config.go
+++ b/pkg/brokerpak/config.go
@@ -17,7 +17,6 @@ package brokerpak
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -160,7 +159,6 @@ func ListBrokerpaks(directory string) ([]string, error) {
 		if err != nil {
 			return err
 		}
-		log.Printf("examining file %v", path)
 		if filepath.Ext(path) == ".brokerpak" {
 			path, err := filepath.Abs(path)
 			if err != nil {


### PR DESCRIPTION
This is a second attempt at #561 that was reverted in #569

This removes a step that made a copy of a local brokerpak before opening
it.

Also the logging of the file walker used to locate brokerpaks has been
removed as this is more commonly annoying and rarely useful

[#181523458](https://www.pivotaltracker.com/story/show/181523458)

### Checklist:

* ~~[ ] Have you added or updated tests to validate the changed functionality?~~
* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

