### PR TITLE
fix: checks that terraform_upgrade_path terminates at default version

### DIFF
--- a/internal/brokerpak/manifest/parser_test.go
+++ b/internal/brokerpak/manifest/parser_test.go
@@ -179,6 +179,7 @@ var _ = Describe("Parser", func() {
 			})
 		})
 	})
+
 	Context("terraform_state_provider_replacements", func() {
 		It("can parse and validate the provider replacements", func() {
 			m, err := manifest.Parse(fakeManifest(with("terraform_state_provider_replacements",
@@ -246,6 +247,16 @@ var _ = Describe("Parser", func() {
 				},
 			)))
 			Expect(err).To(MatchError(ContainSubstring(`no corresponding terrafom resource for terraform version "1.2.3": terraform_upgrade_path[0].version`)))
+			Expect(m).To(BeNil())
+		})
+
+		It("must upgrade up to the default version", func() {
+			m, err := manifest.Parse(fakeManifest(with("terraform_upgrade_path",
+				[]map[string]any{
+					{"version": "1.1.4"},
+				},
+			)))
+			Expect(err).To(MatchError(ContainSubstring(`upgrade path does not terminate at default version: terraform_upgrade_path[0].version`)))
 			Expect(m).To(BeNil())
 		})
 	})


### PR DESCRIPTION
A common error is to add a new default Terraform version and fail to
update the terraform_upgrade_path. This adds a check so that if the
terraform_upgrade_path does not terminate at the default version then
the brokerpak will fail to build, resulting in faster feedback.

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

