### PR TITLE
fix: upgrade should handle addition of properties

### DIFF
--- a/integrationtest/fixtures/terraform-upgrade-updated/fake-bind.tf
+++ b/integrationtest/fixtures/terraform-upgrade-updated/fake-bind.tf
@@ -15,7 +15,3 @@ resource "random_integer" "priority" {
 output "provision_output" {
   value = random_integer.priority.result
 }
-
-output "new_output" {
-  value = 42
-}

--- a/integrationtest/fixtures/terraform-upgrade-updated/fake-service.yml
+++ b/integrationtest/fixtures/terraform-upgrade-updated/fake-service.yml
@@ -19,14 +19,21 @@ provision:
       type: string
       details: alpha input
   outputs:
-      - field_name: provision_output
-        type: integer
-        details: provision output
+    - field_name: provision_output
+      type: integer
+      details: provision output
+    - field_name: new_output
+      type: integer
+      details: new provision output
 bind:
   template_refs:
-    main: fake-provision.tf
+    main: fake-bind.tf
+  computed_inputs:
+    - name: new_input
+      type: integer
+      default: ${instance.details["new_output"]}
   outputs:
-      - field_name: provision_output
-        type: integer
-        details: provision output
+    - field_name: provision_output
+      type: integer
+      details: provision output
 

--- a/integrationtest/fixtures/terraform-upgrade/fake-bind.tf
+++ b/integrationtest/fixtures/terraform-upgrade/fake-bind.tf
@@ -1,0 +1,10 @@
+provider "random" { }
+
+resource "random_integer" "priority" {
+  min = 1
+  max = 2
+}
+
+output "provision_output" {
+  value = random_integer.priority.result
+}

--- a/integrationtest/fixtures/terraform-upgrade/fake-service.yml
+++ b/integrationtest/fixtures/terraform-upgrade/fake-service.yml
@@ -24,7 +24,7 @@ provision:
       details: provision output
 bind:
   template_refs:
-    main: fake-provision.tf
+    main: fake-bind.tf
   outputs:
     - field_name: provision_output
       type: integer

--- a/pkg/broker/brokerfakes/fake_service_provider.go
+++ b/pkg/broker/brokerfakes/fake_service_provider.go
@@ -152,19 +152,31 @@ type FakeServiceProvider struct {
 		result1 models.ServiceInstanceDetails
 		result2 error
 	}
-	UpgradeStub        func(context.Context, *varcontext.VarContext, []*varcontext.VarContext) (models.ServiceInstanceDetails, error)
-	upgradeMutex       sync.RWMutex
-	upgradeArgsForCall []struct {
+	UpgradeBindingsStub        func(context.Context, *varcontext.VarContext, []*varcontext.VarContext) error
+	upgradeBindingsMutex       sync.RWMutex
+	upgradeBindingsArgsForCall []struct {
 		arg1 context.Context
 		arg2 *varcontext.VarContext
 		arg3 []*varcontext.VarContext
 	}
-	upgradeReturns struct {
-		result1 models.ServiceInstanceDetails
+	upgradeBindingsReturns struct {
+		result1 error
+	}
+	upgradeBindingsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	UpgradeInstanceStub        func(context.Context, *varcontext.VarContext) (*sync.WaitGroup, error)
+	upgradeInstanceMutex       sync.RWMutex
+	upgradeInstanceArgsForCall []struct {
+		arg1 context.Context
+		arg2 *varcontext.VarContext
+	}
+	upgradeInstanceReturns struct {
+		result1 *sync.WaitGroup
 		result2 error
 	}
-	upgradeReturnsOnCall map[int]struct {
-		result1 models.ServiceInstanceDetails
+	upgradeInstanceReturnsOnCall map[int]struct {
+		result1 *sync.WaitGroup
 		result2 error
 	}
 	invocations      map[string][][]interface{}
@@ -824,25 +836,87 @@ func (fake *FakeServiceProvider) UpdateReturnsOnCall(i int, result1 models.Servi
 	}{result1, result2}
 }
 
-func (fake *FakeServiceProvider) Upgrade(arg1 context.Context, arg2 *varcontext.VarContext, arg3 []*varcontext.VarContext) (models.ServiceInstanceDetails, error) {
+func (fake *FakeServiceProvider) UpgradeBindings(arg1 context.Context, arg2 *varcontext.VarContext, arg3 []*varcontext.VarContext) error {
 	var arg3Copy []*varcontext.VarContext
 	if arg3 != nil {
 		arg3Copy = make([]*varcontext.VarContext, len(arg3))
 		copy(arg3Copy, arg3)
 	}
-	fake.upgradeMutex.Lock()
-	ret, specificReturn := fake.upgradeReturnsOnCall[len(fake.upgradeArgsForCall)]
-	fake.upgradeArgsForCall = append(fake.upgradeArgsForCall, struct {
+	fake.upgradeBindingsMutex.Lock()
+	ret, specificReturn := fake.upgradeBindingsReturnsOnCall[len(fake.upgradeBindingsArgsForCall)]
+	fake.upgradeBindingsArgsForCall = append(fake.upgradeBindingsArgsForCall, struct {
 		arg1 context.Context
 		arg2 *varcontext.VarContext
 		arg3 []*varcontext.VarContext
 	}{arg1, arg2, arg3Copy})
-	stub := fake.UpgradeStub
-	fakeReturns := fake.upgradeReturns
-	fake.recordInvocation("Upgrade", []interface{}{arg1, arg2, arg3Copy})
-	fake.upgradeMutex.Unlock()
+	stub := fake.UpgradeBindingsStub
+	fakeReturns := fake.upgradeBindingsReturns
+	fake.recordInvocation("UpgradeBindings", []interface{}{arg1, arg2, arg3Copy})
+	fake.upgradeBindingsMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeServiceProvider) UpgradeBindingsCallCount() int {
+	fake.upgradeBindingsMutex.RLock()
+	defer fake.upgradeBindingsMutex.RUnlock()
+	return len(fake.upgradeBindingsArgsForCall)
+}
+
+func (fake *FakeServiceProvider) UpgradeBindingsCalls(stub func(context.Context, *varcontext.VarContext, []*varcontext.VarContext) error) {
+	fake.upgradeBindingsMutex.Lock()
+	defer fake.upgradeBindingsMutex.Unlock()
+	fake.UpgradeBindingsStub = stub
+}
+
+func (fake *FakeServiceProvider) UpgradeBindingsArgsForCall(i int) (context.Context, *varcontext.VarContext, []*varcontext.VarContext) {
+	fake.upgradeBindingsMutex.RLock()
+	defer fake.upgradeBindingsMutex.RUnlock()
+	argsForCall := fake.upgradeBindingsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeServiceProvider) UpgradeBindingsReturns(result1 error) {
+	fake.upgradeBindingsMutex.Lock()
+	defer fake.upgradeBindingsMutex.Unlock()
+	fake.UpgradeBindingsStub = nil
+	fake.upgradeBindingsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeServiceProvider) UpgradeBindingsReturnsOnCall(i int, result1 error) {
+	fake.upgradeBindingsMutex.Lock()
+	defer fake.upgradeBindingsMutex.Unlock()
+	fake.UpgradeBindingsStub = nil
+	if fake.upgradeBindingsReturnsOnCall == nil {
+		fake.upgradeBindingsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.upgradeBindingsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeServiceProvider) UpgradeInstance(arg1 context.Context, arg2 *varcontext.VarContext) (*sync.WaitGroup, error) {
+	fake.upgradeInstanceMutex.Lock()
+	ret, specificReturn := fake.upgradeInstanceReturnsOnCall[len(fake.upgradeInstanceArgsForCall)]
+	fake.upgradeInstanceArgsForCall = append(fake.upgradeInstanceArgsForCall, struct {
+		arg1 context.Context
+		arg2 *varcontext.VarContext
+	}{arg1, arg2})
+	stub := fake.UpgradeInstanceStub
+	fakeReturns := fake.upgradeInstanceReturns
+	fake.recordInvocation("UpgradeInstance", []interface{}{arg1, arg2})
+	fake.upgradeInstanceMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -850,47 +924,47 @@ func (fake *FakeServiceProvider) Upgrade(arg1 context.Context, arg2 *varcontext.
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeServiceProvider) UpgradeCallCount() int {
-	fake.upgradeMutex.RLock()
-	defer fake.upgradeMutex.RUnlock()
-	return len(fake.upgradeArgsForCall)
+func (fake *FakeServiceProvider) UpgradeInstanceCallCount() int {
+	fake.upgradeInstanceMutex.RLock()
+	defer fake.upgradeInstanceMutex.RUnlock()
+	return len(fake.upgradeInstanceArgsForCall)
 }
 
-func (fake *FakeServiceProvider) UpgradeCalls(stub func(context.Context, *varcontext.VarContext, []*varcontext.VarContext) (models.ServiceInstanceDetails, error)) {
-	fake.upgradeMutex.Lock()
-	defer fake.upgradeMutex.Unlock()
-	fake.UpgradeStub = stub
+func (fake *FakeServiceProvider) UpgradeInstanceCalls(stub func(context.Context, *varcontext.VarContext) (*sync.WaitGroup, error)) {
+	fake.upgradeInstanceMutex.Lock()
+	defer fake.upgradeInstanceMutex.Unlock()
+	fake.UpgradeInstanceStub = stub
 }
 
-func (fake *FakeServiceProvider) UpgradeArgsForCall(i int) (context.Context, *varcontext.VarContext, []*varcontext.VarContext) {
-	fake.upgradeMutex.RLock()
-	defer fake.upgradeMutex.RUnlock()
-	argsForCall := fake.upgradeArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+func (fake *FakeServiceProvider) UpgradeInstanceArgsForCall(i int) (context.Context, *varcontext.VarContext) {
+	fake.upgradeInstanceMutex.RLock()
+	defer fake.upgradeInstanceMutex.RUnlock()
+	argsForCall := fake.upgradeInstanceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeServiceProvider) UpgradeReturns(result1 models.ServiceInstanceDetails, result2 error) {
-	fake.upgradeMutex.Lock()
-	defer fake.upgradeMutex.Unlock()
-	fake.UpgradeStub = nil
-	fake.upgradeReturns = struct {
-		result1 models.ServiceInstanceDetails
+func (fake *FakeServiceProvider) UpgradeInstanceReturns(result1 *sync.WaitGroup, result2 error) {
+	fake.upgradeInstanceMutex.Lock()
+	defer fake.upgradeInstanceMutex.Unlock()
+	fake.UpgradeInstanceStub = nil
+	fake.upgradeInstanceReturns = struct {
+		result1 *sync.WaitGroup
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeServiceProvider) UpgradeReturnsOnCall(i int, result1 models.ServiceInstanceDetails, result2 error) {
-	fake.upgradeMutex.Lock()
-	defer fake.upgradeMutex.Unlock()
-	fake.UpgradeStub = nil
-	if fake.upgradeReturnsOnCall == nil {
-		fake.upgradeReturnsOnCall = make(map[int]struct {
-			result1 models.ServiceInstanceDetails
+func (fake *FakeServiceProvider) UpgradeInstanceReturnsOnCall(i int, result1 *sync.WaitGroup, result2 error) {
+	fake.upgradeInstanceMutex.Lock()
+	defer fake.upgradeInstanceMutex.Unlock()
+	fake.UpgradeInstanceStub = nil
+	if fake.upgradeInstanceReturnsOnCall == nil {
+		fake.upgradeInstanceReturnsOnCall = make(map[int]struct {
+			result1 *sync.WaitGroup
 			result2 error
 		})
 	}
-	fake.upgradeReturnsOnCall[i] = struct {
-		result1 models.ServiceInstanceDetails
+	fake.upgradeInstanceReturnsOnCall[i] = struct {
+		result1 *sync.WaitGroup
 		result2 error
 	}{result1, result2}
 }
@@ -918,8 +992,10 @@ func (fake *FakeServiceProvider) Invocations() map[string][][]interface{} {
 	defer fake.unbindMutex.RUnlock()
 	fake.updateMutex.RLock()
 	defer fake.updateMutex.RUnlock()
-	fake.upgradeMutex.RLock()
-	defer fake.upgradeMutex.RUnlock()
+	fake.upgradeBindingsMutex.RLock()
+	defer fake.upgradeBindingsMutex.RUnlock()
+	fake.upgradeInstanceMutex.RLock()
+	defer fake.upgradeInstanceMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/broker/service_provider.go
+++ b/pkg/broker/service_provider.go
@@ -16,6 +16,7 @@ package broker
 
 import (
 	"context"
+	"sync"
 
 	"github.com/cloudfoundry/cloud-service-broker/dbservice/models"
 	"github.com/cloudfoundry/cloud-service-broker/internal/storage"
@@ -37,8 +38,8 @@ type ServiceProvider interface {
 	// Update makes necessary updates to resources so they match new desired configuration
 	Update(ctx context.Context, updateContext *varcontext.VarContext) (models.ServiceInstanceDetails, error)
 
-	// Upgrade makes necessary upgrades to resources so they match plan configuration
-	Upgrade(ctx context.Context, instanceContext *varcontext.VarContext, bindingContexts []*varcontext.VarContext) (models.ServiceInstanceDetails, error)
+	UpgradeInstance(ctx context.Context, instanceContext *varcontext.VarContext) (*sync.WaitGroup, error)
+	UpgradeBindings(ctx context.Context, instanceContext *varcontext.VarContext, bindingContexts []*varcontext.VarContext) error
 
 	// GetImportedProperties extracts properties that should have been saved as part of subsume operation
 	GetImportedProperties(ctx context.Context, planGUID string, instanceGUID string, inputVariables []BrokerVariable) (map[string]any, error)

--- a/pkg/providers/tf/upgrade.go
+++ b/pkg/providers/tf/upgrade.go
@@ -3,6 +3,7 @@ package tf
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/hashicorp/go-version"
 
@@ -13,40 +14,31 @@ import (
 	"github.com/cloudfoundry/cloud-service-broker/utils/correlation"
 )
 
-// Upgrade makes necessary updates to resources so they match plan configuration
-func (provider *TerraformProvider) Upgrade(ctx context.Context, instanceContext *varcontext.VarContext, bindingContexts []*varcontext.VarContext) (models.ServiceInstanceDetails, error) {
-	provider.logger.Debug("upgrade", correlation.ID(ctx), lager.Data{
+func (provider *TerraformProvider) UpgradeInstance(ctx context.Context, instanceContext *varcontext.VarContext) (*sync.WaitGroup, error) {
+	provider.logger.Debug("upgrade-instance", correlation.ID(ctx), lager.Data{
 		"context": instanceContext.ToMap(),
 	})
 
 	instanceDeploymentID := instanceContext.GetString("tf_id")
 	if err := instanceContext.Error(); err != nil {
-		return models.ServiceInstanceDetails{}, err
+		return nil, err
 	}
 
 	if err := provider.UpdateWorkspaceHCL(instanceDeploymentID, provider.serviceDefinition.ProvisionSettings, instanceContext.ToMap()); err != nil {
-		return models.ServiceInstanceDetails{}, err
+		return nil, err
 	}
 
 	instanceDeployment, err := provider.GetTerraformDeployment(instanceDeploymentID)
 	if err != nil {
-		return models.ServiceInstanceDetails{}, err
+		return nil, err
 	}
 
 	if err := provider.MarkOperationStarted(&instanceDeployment, models.UpgradeOperationType); err != nil {
-		return models.ServiceInstanceDetails{}, err
+		return nil, err
 	}
 
-	for _, bindingContext := range bindingContexts {
-		bindingDeploymentID := bindingContext.GetString("tf_id")
-		if err := provider.UpdateWorkspaceHCL(bindingDeploymentID, provider.serviceDefinition.BindSettings, bindingContext.ToMap()); err != nil {
-			return models.ServiceInstanceDetails{}, err
-		}
-	}
-	bindingDeployments, err := provider.GetBindingDeployments(instanceDeploymentID)
-	if err != nil {
-		return models.ServiceInstanceDetails{}, err
-	}
+	var finished sync.WaitGroup
+	finished.Add(1)
 
 	go func() {
 		err = provider.performTerraformUpgrade(ctx, instanceDeployment.Workspace)
@@ -55,6 +47,42 @@ func (provider *TerraformProvider) Upgrade(ctx context.Context, instanceContext 
 			return
 		}
 
+		if err := provider.MarkOperationStarted(&instanceDeployment, models.UpgradeOperationType); err != nil {
+			panic(err)
+		}
+		finished.Done()
+	}()
+
+	return &finished, nil
+}
+
+func (provider *TerraformProvider) UpgradeBindings(ctx context.Context, instanceContext *varcontext.VarContext, bindingContexts []*varcontext.VarContext) error {
+	provider.logger.Debug("upgrade-bindings", correlation.ID(ctx), lager.Data{
+		"context": instanceContext.ToMap(),
+	})
+
+	instanceDeploymentID := instanceContext.GetString("tf_id")
+	if err := instanceContext.Error(); err != nil {
+		return err
+	}
+
+	instanceDeployment, err := provider.GetTerraformDeployment(instanceDeploymentID)
+	if err != nil {
+		return err
+	}
+
+	for _, bindingContext := range bindingContexts {
+		bindingDeploymentID := bindingContext.GetString("tf_id")
+		if err := provider.UpdateWorkspaceHCL(bindingDeploymentID, provider.serviceDefinition.BindSettings, bindingContext.ToMap()); err != nil {
+			return err
+		}
+	}
+	bindingDeployments, err := provider.GetBindingDeployments(instanceDeploymentID)
+	if err != nil {
+		return err
+	}
+
+	go func() {
 		for i := range bindingDeployments {
 			err = provider.performTerraformUpgrade(ctx, bindingDeployments[i].Workspace)
 			provider.MarkOperationFinished(&bindingDeployments[i], err)
@@ -67,7 +95,7 @@ func (provider *TerraformProvider) Upgrade(ctx context.Context, instanceContext 
 		provider.MarkOperationFinished(&instanceDeployment, err)
 	}()
 
-	return models.ServiceInstanceDetails{}, nil
+	return nil
 }
 
 func (provider *TerraformProvider) performTerraformUpgrade(ctx context.Context, workspace workspace.Workspace) error {


### PR DESCRIPTION
We observed that the upgrade flow failed when an output property was
added to the service instance. This is because the inputs to binding
were computed before the upgrade had happened, and the value of the new
output was not available. This change splits the upgrade of the service
instance from the upgrade of the service binding, allowing the flow to
work.

There was considerable friction in implementing this because of the
false abstraction of the provider layer from the brokerapi layer. This
abstraction made sense when this repo was a Google project that
supported Terraform and Google API, but it doesn't make sense now, and
should be removed in the near future.

[#182855842](https://www.pivotaltracker.com/story/show/182855842)

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~ not relevant to brokerpak consumers
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

