### PR TITLE
chore: "go fmt" and fixes for Go 1.19

### DIFF
--- a/brokerpaktestframework/test_instance.go
+++ b/brokerpaktestframework/test_instance.go
@@ -223,6 +223,7 @@ func (instance *TestInstance) BrokerURL(subPath string) string {
 
 // BrokerUrl returns the URL of the broker. Use BrokerURL instead.
 // Deprecated: due to name that does not conform to Go initialisms:  https://github.com/golang/go/wiki/CodeReviewComments#initialisms
+//
 //lint:ignore ST1003 to maintain backwards compatability
 func (instance *TestInstance) BrokerUrl(subPath string) string {
 	return instance.BrokerURL(subPath)

--- a/integrationtest/integrationtest_suite_test.go
+++ b/integrationtest/integrationtest_suite_test.go
@@ -18,7 +18,9 @@ var csb string
 
 var _ = SynchronizedBeforeSuite(
 	func() []byte {
-		path, err := Build("github.com/cloudfoundry/cloud-service-broker", `-gcflags="all=-N -l"`)
+		// -gcflags enabled "gops", but had to be removed as this doesn't compile with Go 1.19
+		//path, err := Build("github.com/cloudfoundry/cloud-service-broker", `-gcflags="all=-N -l"`)
+		path, err := Build("github.com/cloudfoundry/cloud-service-broker")
 		Expect(err).NotTo(HaveOccurred())
 		return []byte(path)
 	},

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -369,14 +369,14 @@ func (svc *ServiceDefinition) bindDefaults() []varcontext.DefaultVariable {
 // Variables have a very specific resolution order. Lower number are overwritten by higher numbers
 // except where noted.
 //
-// 1. Global defaults: key/value pairs set in JSON in Viper `provision.defaults`
-// 2. Service defaults: key/value pairs set in JSON in Viper `service.<service>.provision.defaults`
-// 3. Request parameters: key/value pairs passed in the provision/update request, typically
-//    with the "-c" parameter of the "cf" command
-// 4. Provision overrides: from the Plan definition "provision_overrides"
-// 5. Default values: from the Service definition YAML "user_inputs", only if the value has not been set above.
-// 6. Plan properties: from the Plan definition key "properties"
-// 7. Computed values: from Service definition YAML "computed_inputs", only if the value has not been set above.
+//  1. Global defaults: key/value pairs set in JSON in Viper `provision.defaults`
+//  2. Service defaults: key/value pairs set in JSON in Viper `service.<service>.provision.defaults`
+//  3. Request parameters: key/value pairs passed in the provision/update request, typically
+//     with the "-c" parameter of the "cf" command
+//  4. Provision overrides: from the Plan definition "provision_overrides"
+//  5. Default values: from the Service definition YAML "user_inputs", only if the value has not been set above.
+//  6. Plan properties: from the Plan definition key "properties"
+//  7. Computed values: from Service definition YAML "computed_inputs", only if the value has not been set above.
 //
 // Default values and Computed values are interpolated in HIL (see pkg/varcontext/interpolation.Eval()),
 // but others are not to prevent side-channel attacks.
@@ -452,7 +452,6 @@ func (svc *ServiceDefinition) UpdateVariables(instanceID string, details parampa
 // 3. User defined variables (in `bind_input_variables`)
 // 4. Operator default variables loaded from the environment.
 // 5. Default variables (in `bind_input_variables`).
-//
 func (svc *ServiceDefinition) BindVariables(instance storage.ServiceInstanceDetails, bindingID string, details paramparser.BindDetails, plan *ServicePlan, originatingIdentity map[string]any) (*varcontext.VarContext, error) {
 	// The namespaces of these values roughly align with the OSB spec.
 	constants := map[string]any{

--- a/pkg/server/health_test.go
+++ b/pkg/server/health_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/pkg/toggles/toggle.go
+++ b/pkg/toggles/toggle.go
@@ -18,7 +18,6 @@ toggles in the service broker.
 
 It mimics Go's `flags` package, but uses Viper as a backing store to abstract
 out how a particular flag is set.
-
 */
 package toggles
 

--- a/pkg/validation/field_error.go
+++ b/pkg/validation/field_error.go
@@ -46,11 +46,12 @@ var _ error = (*FieldError)(nil)
 
 // ViaField is used to propagate a validation error along a field access.
 // For example, if a type recursively validates its "spec" via:
-//   if err := foo.Spec.Validate(); err != nil {
-//     // Augment any field paths with the context that they were accessed
-//     // via "spec".
-//     return err.ViaField("spec")
-//   }
+//
+//	if err := foo.Spec.Validate(); err != nil {
+//	  // Augment any field paths with the context that they were accessed
+//	  // via "spec".
+//	  return err.ViaField("spec")
+//	}
 func (e *FieldError) ViaField(prefix ...string) *FieldError {
 	if e == nil {
 		return nil
@@ -76,11 +77,12 @@ func (e *FieldError) ViaField(prefix ...string) *FieldError {
 
 // ViaIndex is used to attach an index to the next ViaField provided.
 // For example, if a type recursively validates a parameter that has a collection:
-//  for i, c := range spec.Collection {
-//    if err := doValidation(c); err != nil {
-//      return err.ViaIndex(i).ViaField("collection")
-//    }
-//  }
+//
+//	for i, c := range spec.Collection {
+//	  if err := doValidation(c); err != nil {
+//	    return err.ViaIndex(i).ViaField("collection")
+//	  }
+//	}
 func (e *FieldError) ViaIndex(index int) *FieldError {
 	return e.ViaField(asIndex(index))
 }
@@ -92,11 +94,12 @@ func (e *FieldError) ViaFieldIndex(field string, index int) *FieldError {
 
 // ViaKey is used to attach a key to the next ViaField provided.
 // For example, if a type recursively validates a parameter that has a collection:
-//  for k, v := range spec.Bag {
-//    if err := doValidation(v); err != nil {
-//      return err.ViaKey(k).ViaField("bag")
-//    }
-//  }
+//
+//	for k, v := range spec.Bag {
+//	  if err := doValidation(v); err != nil {
+//	    return err.ViaKey(k).ViaField("bag")
+//	  }
+//	}
 func (e *FieldError) ViaKey(key string) *FieldError {
 	return e.ViaField(asKey(key))
 }
@@ -190,10 +193,11 @@ func asKey(key string) string {
 
 // flatten takes in a array of path components and looks for chances to flatten
 // objects that have index prefixes, examples:
-//   err([0]).ViaField(bar).ViaField(foo) -> foo.bar.[0] converts to foo.bar[0]
-//   err(bar).ViaIndex(0).ViaField(foo) -> foo.[0].bar converts to foo[0].bar
-//   err(bar).ViaField(foo).ViaIndex(0) -> [0].foo.bar converts to [0].foo.bar
-//   err(bar).ViaIndex(0).ViaIndex(1).ViaField(foo) -> foo.[1].[0].bar converts to foo[1][0].bar
+//
+//	err([0]).ViaField(bar).ViaField(foo) -> foo.bar.[0] converts to foo.bar[0]
+//	err(bar).ViaIndex(0).ViaField(foo) -> foo.[0].bar converts to foo[0].bar
+//	err(bar).ViaField(foo).ViaIndex(0) -> [0].foo.bar converts to [0].foo.bar
+//	err(bar).ViaIndex(0).ViaIndex(1).ViaField(foo) -> foo.[1].[0].bar converts to foo[1][0].bar
 func flatten(path []string) string {
 	var newPath []string
 	for _, part := range path {


### PR DESCRIPTION
There have been some format changes and a change to -gcflags. "gops"
integration was disabled, but it might be easy to re-add it with a
syntax change to the -gcflags argument.

### Checklist:

* ~~[ ] Have you added or updated tests to validate the changed functionality?~~
* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

