### PR TITLE
feat: experimental "create-service" command

### DIFF
--- a/cmd/create_service.go
+++ b/cmd/create_service.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/cloudfoundry/cloud-service-broker/internal/createservice"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func init() {
+	var c string
+
+	clientCmd := &cobra.Command{
+		Use:     "create-service SERVICE PLAN NAME",
+		Aliases: []string{"cs"},
+		Short:   "EXPERIMENTAL AND SUBJECT TO BREAKING CHANGE: create a service instance",
+		Args:    cobra.ExactArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			createservice.Run(args[0], args[1], args[2], c, viper.GetString(pakCachePath))
+		},
+	}
+	clientCmd.Flags().StringVarP(&c, "c", "c", "", "parameters as JSON")
+
+	rootCmd.AddCommand(clientCmd)
+}

--- a/internal/brokerpak/packer/pack.go
+++ b/internal/brokerpak/packer/pack.go
@@ -91,7 +91,11 @@ func packSources(m *manifest.Manifest, tmp string, cachePath string) error {
 }
 
 func getAny(source, destination string) error {
-	return getter.GetAny(destination, source)
+	err := getter.GetAny(destination, source)
+	if err != nil {
+		return fmt.Errorf("error getting %q: %w", source, err)
+	}
+	return nil
 }
 
 func packBinaries(m *manifest.Manifest, tmp string, cachePath string) error {

--- a/internal/createservice/create_service.go
+++ b/internal/createservice/create_service.go
@@ -1,0 +1,201 @@
+package createservice
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+
+	"github.com/cloudfoundry/cloud-service-broker/pkg/client"
+
+	"github.com/cloudfoundry/cloud-service-broker/pkg/brokerpak"
+	"github.com/pborman/uuid"
+)
+
+func Run(service, plan, name, c, cachePath string) {
+	pakPath := pack(cachePath)
+	port := freePort()
+	username := uuid.New()
+	password := uuid.New()
+	workdir, err := os.MkdirTemp("", "csb-*")
+	if err != nil {
+		panic(err)
+	}
+	pakPath, err = filepath.Abs(pakPath)
+	if err != nil {
+		panic(err)
+	}
+	os.Symlink(pakPath, filepath.Join(workdir, filepath.Base(pakPath)))
+	cwd, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	dbfile := filepath.Join(cwd, ".csb.db")
+	h := start(username, password, workdir, dbfile, port)
+	defer h.Terminate()
+
+	wait(port, h)
+
+	clnt, err := client.New(username, password, "localhost", port)
+	if err != nil {
+		panic(err)
+	}
+	serviceID, planID := lookupServiceInfo(clnt, service, plan)
+	instanceID := NameToID(name)
+	provision(clnt, instanceID, serviceID, planID)
+	fmt.Printf("**** HERE 2 %s %s\n", serviceID, planID)
+
+	for start := time.Now(); lastOperation(clnt, instanceID); {
+		if time.Since(start) > time.Hour {
+			panic("timed out")
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func lastOperation(clnt *client.Client, instanceID string) bool {
+	lastOperationResponse := clnt.LastOperation(instanceID, uuid.New())
+	switch {
+	case lastOperationResponse.Error != nil:
+		panic(lastOperationResponse.Error)
+	case lastOperationResponse.StatusCode != http.StatusOK:
+		panic(fmt.Sprintf("unexpected last operation response: %d", lastOperationResponse.StatusCode))
+	}
+
+	var lo domain.LastOperation
+	if err := json.Unmarshal(lastOperationResponse.ResponseBody, &lo); err != nil {
+		panic(err)
+	}
+
+	switch lo.State {
+	case domain.InProgress:
+		return true
+	case domain.Succeeded:
+		return false
+	default:
+		panic(fmt.Sprintf("provision failed: %s", lo.Description))
+	}
+}
+
+func provision(clnt *client.Client, instanceID, serviceID, planID string) {
+	provisionResponse := clnt.Provision(instanceID, serviceID, planID, uuid.New(), nil)
+	switch {
+	case provisionResponse.Error != nil:
+		panic(fmt.Sprintf("provision error: %s", provisionResponse.Error))
+	case provisionResponse.StatusCode != http.StatusAccepted:
+		panic(fmt.Sprintf("unexpected provision reponse: %d", provisionResponse.StatusCode))
+	}
+}
+
+func lookupServiceInfo(clnt *client.Client, serviceName, planName string) (string, string) {
+	catalogResponse := clnt.Catalog(uuid.New())
+	switch {
+	case catalogResponse.Error != nil:
+		panic(catalogResponse.Error)
+	case catalogResponse.StatusCode != http.StatusOK:
+		panic(fmt.Sprintf("bad catalog response %d: %s", catalogResponse.StatusCode, catalogResponse.String()))
+	}
+
+	var catalog struct {
+		Services []domain.Service `json:"services"`
+	}
+	if err := json.Unmarshal(catalogResponse.ResponseBody, &catalog); err != nil {
+		panic(err)
+	}
+
+	for _, s := range catalog.Services {
+		if s.Name == serviceName {
+			for _, p := range s.Plans {
+				if p.Name == planName {
+					return s.ID, p.ID
+				}
+			}
+			panic(fmt.Sprintf("could not find plan %q in service %q", planName, serviceName))
+		}
+	}
+	panic(fmt.Sprintf("could not find service %q in catalog", serviceName))
+}
+
+func newHandle(cmd *exec.Cmd) *handle {
+	h := handle{cmd: cmd}
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			panic(fmt.Sprintf("server process failed: %s", err))
+		}
+		h.Exited = true
+	}()
+	return &h
+}
+
+type handle struct {
+	cmd    *exec.Cmd
+	Exited bool
+}
+
+func (h *handle) Terminate() {
+	h.cmd.Process.Kill()
+}
+
+func start(username, password, workdir, dbfile string, port int) *handle {
+	cmd := exec.Command(os.Args[0], "serve")
+	cmd.Dir = workdir
+	cmd.Env = append(
+		os.Environ(),
+		"CSB_LISTENER_HOST=localhost",
+		"DB_TYPE=sqlite3",
+		fmt.Sprintf("DB_PATH=%s", dbfile),
+		fmt.Sprintf("PORT=%d", port),
+		fmt.Sprintf("SECURITY_USER_NAME=%s", username),
+		fmt.Sprintf("SECURITY_USER_PASSWORD=%s", password),
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		panic(err)
+	}
+
+	return newHandle(cmd)
+}
+
+func wait(port int, h *handle) {
+	for start := time.Now(); time.Since(start) < 5*time.Minute && !h.Exited; {
+		res, err := http.Get(fmt.Sprintf("http://localhost:%d//info", port))
+		if err == nil && res.StatusCode == http.StatusOK {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("timed out or died")
+}
+
+func pack(cachePath string) string {
+	pakPath, err := brokerpak.Pack("", cachePath, false)
+	if err != nil {
+		log.Fatalf("error while packing: %v", err)
+	}
+
+	if err := brokerpak.Validate(pakPath); err != nil {
+		log.Fatalf("created: %v, but it failed validity checking: %v\n", pakPath, err)
+	} else {
+		fmt.Printf("created: %v\n", pakPath)
+	}
+
+	return pakPath
+}
+
+// TODO: this is the third copy of this in the codebase. Reduce that.
+func freePort() int {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		panic("unable to open a listener port")
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}

--- a/internal/createservice/nameid.go
+++ b/internal/createservice/nameid.go
@@ -1,0 +1,18 @@
+package createservice
+
+import (
+	"fmt"
+)
+
+func NameToID(name string) string {
+	if len(name) > 16 {
+		panic("name too long")
+	}
+
+	for len(name) < 16 {
+		name = name + "."
+	}
+
+	h := []byte(fmt.Sprintf("%x", name))
+	return fmt.Sprintf("%s-%s-%s-%s-%s", h[0:8], h[8:12], h[12:16], h[16:20], h[20:32])
+}


### PR DESCRIPTION
This is an experimental new command that mimics the CloudFoundry
"create-service" command, but runs all steps locally. The aim is to
speed up development by allowing for faster iteration when making
changes to brokerpaks.

### Checklist:

* ~~[ ] Have you added or updated tests to validate the changed functionality?~~ experimental
* ~~[ ] Have you added Draft Release Notes in `docs/draft-release-notes.md`?~~ experimental
* [x] Have you followed the [Conventional Commits specification]~(https://www.conventionalcommits.org/en/v1.0.0/#summary)?

