### PR TITLE
feat(pak): "pak build" --target flag targets specific os/arch or "current"

### DIFF
--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -2,3 +2,4 @@
 
 # Features
 - introduced the ability for typed input fields to optionally be set to `null`
+- **pak build now has --target flag** which allows the build to target a specific platform/architecture or "current"

--- a/integrationtest/brokerpak_build_test.go
+++ b/integrationtest/brokerpak_build_test.go
@@ -1,11 +1,14 @@
 package integrationtest_test
 
 import (
+	"fmt"
 	"os"
 	"path"
+	"runtime"
 	"time"
 
 	"github.com/cloudfoundry/cloud-service-broker/integrationtest/helper"
+	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/platform"
 	"github.com/cloudfoundry/cloud-service-broker/internal/zippy"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -63,10 +66,10 @@ var _ = Describe("Brokerpak Build", func() {
 
 			By("checking that the expected files are there", func() {
 				paths := []string{
-					"bin/linux/amd64/0.12.21/terraform",
-					"bin/linux/amd64/0.13.4/terraform",
-					"bin/linux/amd64/cloud-service-broker.linux",
-					"bin/linux/amd64/extrafile.sh",
+					fmt.Sprintf("bin/%s/0.12.21/terraform", platform.CurrentPlatform()),
+					fmt.Sprintf("bin/%s/0.13.4/terraform", platform.CurrentPlatform()),
+					fmt.Sprintf("bin/%s/cloud-service-broker.%s", platform.CurrentPlatform(), runtime.GOOS),
+					fmt.Sprintf("bin/%s/extrafile.sh", platform.CurrentPlatform()),
 				}
 				for _, p := range paths {
 					Expect(path.Join(extractedPath, p)).To(BeAnExistingFile())

--- a/integrationtest/helper/build_brokerpak.go
+++ b/integrationtest/helper/build_brokerpak.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (h *TestHelper) BuildBrokerpakCommand(paths ...string) *exec.Cmd {
-	return exec.Command(h.csb, "pak", "build", path.Join(paths...))
+	return exec.Command(h.csb, "pak", "build", "--target", "current", path.Join(paths...))
 }
 
 func (h *TestHelper) BuildBrokerpak(paths ...string) {

--- a/internal/brokerpak/packer/pack.go
+++ b/internal/brokerpak/packer/pack.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/hashicorp/go-getter"
-
 	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/brokerpakurl"
 	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/fetcher"
 	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/manifest"
@@ -17,6 +15,7 @@ import (
 	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf"
 	"github.com/cloudfoundry/cloud-service-broker/utils"
 	"github.com/cloudfoundry/cloud-service-broker/utils/stream"
+	"github.com/hashicorp/go-getter"
 )
 
 const manifestName = "manifest.yml"

--- a/internal/brokerpak/platform/platform.go
+++ b/internal/brokerpak/platform/platform.go
@@ -18,9 +18,31 @@ package platform
 import (
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/cloudfoundry/cloud-service-broker/pkg/validation"
 )
+
+// CurrentPlatform returns the platform defined by GOOS and GOARCH.
+func CurrentPlatform() Platform {
+	return Platform{Os: runtime.GOOS, Arch: runtime.GOARCH}
+}
+
+func Parse(s string) Platform {
+	if s == "current" {
+		return CurrentPlatform()
+	}
+	parts := strings.SplitN(s, "/", 2)
+	switch len(parts) {
+	case 2:
+		return Platform{
+			Os:   parts[0],
+			Arch: parts[1],
+		}
+	default:
+		return Platform{}
+	}
+}
 
 // Platform holds an os/architecture pair.
 type Platform struct {
@@ -53,7 +75,6 @@ func (p Platform) MatchesCurrent() bool {
 	return p.Equals(CurrentPlatform())
 }
 
-// CurrentPlatform returns the platform defined by GOOS and GOARCH.
-func CurrentPlatform() Platform {
-	return Platform{Os: runtime.GOOS, Arch: runtime.GOARCH}
+func (p Platform) Empty() bool {
+	return p.Os == "" && p.Arch == ""
 }

--- a/internal/brokerpak/platform/platform_test.go
+++ b/internal/brokerpak/platform/platform_test.go
@@ -65,3 +65,43 @@ func TestPlatform_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestPlatform_Parse(t *testing.T) {
+	t.Run("valid platform name", func(t *testing.T) {
+		const e = "darwin/amd64"
+		r := platform.Parse(e).String()
+		if r != e {
+			t.Fatalf("expected %q got %q", e, r)
+		}
+	})
+
+	t.Run("special case `current`", func(t *testing.T) {
+		e := platform.CurrentPlatform().String()
+		r := platform.Parse("current").String()
+		if r != e {
+			t.Fatalf("expected %q got %q", e, r)
+		}
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		r := platform.Parse("")
+		if !r.Empty() {
+			t.Fatalf("unexpectedly not empty")
+		}
+	})
+}
+
+func TestPlatform_Empty(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		p := platform.Platform{}
+		if !p.Empty() {
+			t.Fatalf("unexpectedly not empty")
+		}
+	})
+
+	t.Run("not empty", func(t *testing.T) {
+		if platform.CurrentPlatform().Empty() {
+			t.Fatalf("expectedly empty")
+		}
+	})
+}

--- a/internal/createservice/create_service.go
+++ b/internal/createservice/create_service.go
@@ -11,12 +11,12 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/pborman/uuid"
-	"github.com/pivotal-cf/brokerapi/v8/domain"
-
+	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/platform"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/brokerpak"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/client"
 	"github.com/cloudfoundry/cloud-service-broker/utils/freeport"
+	"github.com/pborman/uuid"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
 )
 
 func Run(service, plan, name, cachePath string) {
@@ -176,7 +176,7 @@ func wait(port int, h *handle) {
 }
 
 func pack(cachePath string) string {
-	pakPath, err := brokerpak.Pack("", cachePath, false)
+	pakPath, err := brokerpak.Pack("", cachePath, false, platform.CurrentPlatform())
 	if err != nil {
 		log.Fatalf("error while packing: %v", err)
 	}

--- a/pkg/brokerpak/cmd.go
+++ b/pkg/brokerpak/cmd.go
@@ -23,14 +23,14 @@ import (
 	"path/filepath"
 	"text/tabwriter"
 
-	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf"
-
 	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/manifest"
 	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/packer"
+	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/platform"
 	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/reader"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/broker"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/client"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/generator"
+	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/server"
 	"github.com/cloudfoundry/cloud-service-broker/utils/stream"
 )
@@ -56,7 +56,7 @@ func Init(directory string) error {
 // Pack creates a new brokerpak from the given directory which MUST contain a
 // manifest.yml file. If the pack was successful, the returned string will be
 // the path to the created brokerpak.
-func Pack(directory string, cachePath string, includeSource bool) (string, error) {
+func Pack(directory string, cachePath string, includeSource bool, target platform.Platform) (string, error) {
 	data, err := os.ReadFile(filepath.Join(directory, manifestName))
 	if err != nil {
 		return "", err
@@ -68,10 +68,14 @@ func Pack(directory string, cachePath string, includeSource bool) (string, error
 	}
 
 	version, ok := os.LookupEnv(m.Version)
-
 	if !ok {
 		version = m.Version
 	}
+
+	if !target.Empty() {
+		m.Platforms = []platform.Platform{target}
+	}
+
 	packname := fmt.Sprintf("%s-%s.brokerpak", m.Name, version)
 	return packname, packer.Pack(m, directory, packname, cachePath, includeSource)
 }

--- a/pkg/brokerpak/cmd_test.go
+++ b/pkg/brokerpak/cmd_test.go
@@ -95,7 +95,7 @@ func fakeBrokerpak() (string, error) {
 		}
 	}
 
-	return Pack(dir, "", true)
+	return Pack(dir, "", true, platform.Platform{})
 }
 
 func ExampleValidate() {


### PR DESCRIPTION
This "--target" flag will override the "platforms" block in the
manifest. It's useful for building for the current platform.

[#181407433](https://www.pivotaltracker.com/story/show/181407433)

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

