### PR TITLE
feat: "pak build" --compress option to disable compression

### DIFF
--- a/brokerpaktestframework/test_instance_builder.go
+++ b/brokerpaktestframework/test_instance_builder.go
@@ -42,7 +42,7 @@ func BuildTestInstance(brokerPackDir string, provider TerraformMock, logger io.W
 		return nil, err
 	}
 
-	command := exec.Command(csbBuild, "pak", "build")
+	command := exec.Command(csbBuild, "pak", "build", "--compress=false")
 	command.Dir = workingDir
 	session, err := gexec.Start(command, logger, logger)
 	if err != nil {

--- a/cmd/pak.go
+++ b/cmd/pak.go
@@ -99,6 +99,7 @@ dependencies, services it provides, and the contents.
 	const (
 		includeSourceFlag = "include-source"
 		targetFlag        = "target"
+		compressFlag      = "compress"
 	)
 	buildCmd := &cobra.Command{
 		Use:   "build [path/to/pack/directory]",
@@ -114,12 +115,16 @@ dependencies, services it provides, and the contents.
 			if err != nil {
 				log.Fatalf("error while obtaining the %q flag: %s", includeSourceFlag, err)
 			}
+			compress, err := cmd.Flags().GetBool(compressFlag)
+			if err != nil {
+				log.Fatalf("error while obtaining the %q flag: %s", compressFlag, err)
+			}
 			target, err := cmd.Flags().GetString(targetFlag)
 			if err != nil {
 				log.Fatalf("error while obtaining the %q flag: %s", targetFlag, err)
 			}
 
-			pakPath, err := brokerpak.Pack(directory, viper.GetString(pakCachePath), includeSource, platform.Parse(target))
+			pakPath, err := brokerpak.Pack(directory, viper.GetString(pakCachePath), includeSource, compress, platform.Parse(target))
 			if err != nil {
 				log.Fatalf("error while packing %q: %v", directory, err)
 			}
@@ -132,6 +137,7 @@ dependencies, services it provides, and the contents.
 		},
 	}
 	buildCmd.Flags().BoolP(includeSourceFlag, "s", false, "include source in the brokerpak")
+	buildCmd.Flags().Bool(compressFlag, true, "compress the brokerpak")
 	buildCmd.Flags().StringP(targetFlag, "t", "", "target specified platform; format 'darwin/amd64'; or special case 'current'")
 	pakCmd.AddCommand(buildCmd)
 
@@ -197,7 +203,7 @@ dependencies, services it provides, and the contents.
 			}
 
 			// Edit the manifest to point to our local server
-			packname, err := brokerpak.Pack(td, "", false, platform.Platform{})
+			packname, err := brokerpak.Pack(td, "", false, true, platform.Platform{})
 			defer os.Remove(packname)
 			if err != nil {
 				log.Fatalf("couldn't pack brokerpak: %v", err)

--- a/docs/draft-release-notes.md
+++ b/docs/draft-release-notes.md
@@ -1,7 +1,8 @@
 ## Release notes for next release:
 
 # Features
-- introduced the ability for typed input fields to optionally be set to `null`
-- **pak build now has --target flag** which allows the build to target a specific platform/architecture or "current"
-- **provider_display_name is now configurable:** the `provider_display_name` can now be configured in the brokerpak services
+- introduced the ability for typed input fields to optionally be set to `null`.
+- **pak build now has --target flag** which allows the build to target a specific platform/architecture or "current".
+- **pak build now has --compress flag** which allows the compression of the brokerpak to be controlled.
+- **provider_display_name is now configurable:** the `provider_display_name` can now be configured in the brokerpak services.
    and it will be returned by the catalog endpoint making it available for display in visual tools. 

--- a/internal/brokerpak/packer/pack.go
+++ b/internal/brokerpak/packer/pack.go
@@ -20,7 +20,7 @@ import (
 
 const manifestName = "manifest.yml"
 
-func Pack(m *manifest.Manifest, base, dest, cachePath string, includeSource bool) error {
+func Pack(m *manifest.Manifest, base, dest, cachePath string, includeSource, compress bool) error {
 	// NOTE: we use "log" rather than Lager because this is used by the CLI and
 	// needs to be human-readable rather than JSON.
 	switch base {
@@ -57,7 +57,7 @@ func Pack(m *manifest.Manifest, base, dest, cachePath string, includeSource bool
 	}
 
 	log.Println("Creating archive:", dest)
-	return zippy.Archive(dir, dest)
+	return zippy.Archive(dir, dest, compress)
 }
 
 func packSources(m *manifest.Manifest, tmp string, cachePath string) error {

--- a/internal/brokerpak/reader/reader_test.go
+++ b/internal/brokerpak/reader/reader_test.go
@@ -226,7 +226,7 @@ func fakeBrokerpak(opts ...option) string {
 	}
 
 	packName := path.Join(GinkgoT().TempDir(), "fake.brokerpak")
-	Expect(packer.Pack(m, dir, packName, "", c.includeSource)).NotTo(HaveOccurred())
+	Expect(packer.Pack(m, dir, packName, "", c.includeSource, false)).NotTo(HaveOccurred())
 	return packName
 }
 

--- a/internal/createservice/create_service.go
+++ b/internal/createservice/create_service.go
@@ -176,7 +176,7 @@ func wait(port int, h *handle) {
 }
 
 func pack(cachePath string) string {
-	pakPath, err := brokerpak.Pack("", cachePath, false, platform.CurrentPlatform())
+	pakPath, err := brokerpak.Pack("", cachePath, false, false, platform.CurrentPlatform())
 	if err != nil {
 		log.Fatalf("error while packing: %v", err)
 	}

--- a/internal/zippy/archive.go
+++ b/internal/zippy/archive.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cloudfoundry/cloud-service-broker/utils/stream"
 )
 
-func Archive(sourceDirectory, destinationZip string) error {
+func Archive(sourceDirectory, destinationZip string, compress bool) error {
 	fd, err := os.Create(destinationZip)
 	if err != nil {
 		return fmt.Errorf("couldn't create archive %q: %v", destinationZip, err)
@@ -39,7 +39,9 @@ func Archive(sourceDirectory, destinationZip string) error {
 		if err != nil {
 			return err
 		}
-		header.Method = zip.Deflate
+		if compress {
+			header.Method = zip.Deflate
+		}
 
 		if info.IsDir() {
 			header.Name = fmt.Sprintf("%s%c", clean(strings.TrimPrefix(path, sourceDirectory)), os.PathSeparator)

--- a/internal/zippy/archive_test.go
+++ b/internal/zippy/archive_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Archive", func() {
 	It("creates a zip", func() {
 		target := path.Join(tmpdir, "test.zip")
 
-		err := zippy.Archive("./fixtures/brokerpak", target)
+		err := zippy.Archive("./fixtures/brokerpak", target, false)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Although we have a brokerpak.zip fixture that we could
@@ -37,18 +37,25 @@ var _ = Describe("Archive", func() {
 		Expect(extracted).To(MatchDirectoryContents("./fixtures/brokerpak"))
 	})
 
+	It("creates a compressed zip", func() {
+		target := path.Join(tmpdir, "test.zip")
+
+		err := zippy.Archive("./fixtures/brokerpak", target, true)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	When("the source does not exist", func() {
 		It("returns an appropriate error", func() {
 			target := path.Join(tmpdir, "test.zip")
 
-			err := zippy.Archive("/this/does/not/exist", target)
+			err := zippy.Archive("/this/does/not/exist", target, false)
 			Expect(err).To(MatchError("lstat /this/does/not/exist: no such file or directory"))
 		})
 	})
 
 	When("the target cannot be written", func() {
 		It("returns an appropriate error", func() {
-			err := zippy.Archive("./fixtures/brokerpak", "/this/does/not/exist")
+			err := zippy.Archive("./fixtures/brokerpak", "/this/does/not/exist", false)
 			Expect(err).To(MatchError(`couldn't create archive "/this/does/not/exist": open /this/does/not/exist: no such file or directory`))
 		})
 	})

--- a/pkg/brokerpak/cmd.go
+++ b/pkg/brokerpak/cmd.go
@@ -56,7 +56,7 @@ func Init(directory string) error {
 // Pack creates a new brokerpak from the given directory which MUST contain a
 // manifest.yml file. If the pack was successful, the returned string will be
 // the path to the created brokerpak.
-func Pack(directory string, cachePath string, includeSource bool, target platform.Platform) (string, error) {
+func Pack(directory string, cachePath string, includeSource, compress bool, target platform.Platform) (string, error) {
 	data, err := os.ReadFile(filepath.Join(directory, manifestName))
 	if err != nil {
 		return "", err
@@ -77,7 +77,7 @@ func Pack(directory string, cachePath string, includeSource bool, target platfor
 	}
 
 	packname := fmt.Sprintf("%s-%s.brokerpak", m.Name, version)
-	return packname, packer.Pack(m, directory, packname, cachePath, includeSource)
+	return packname, packer.Pack(m, directory, packname, cachePath, includeSource, compress)
 }
 
 // Info writes out human-readable information about the brokerpak.

--- a/pkg/brokerpak/cmd_test.go
+++ b/pkg/brokerpak/cmd_test.go
@@ -95,7 +95,7 @@ func fakeBrokerpak() (string, error) {
 		}
 	}
 
-	return Pack(dir, "", true, platform.Platform{})
+	return Pack(dir, "", true, false, platform.Platform{})
 }
 
 func ExampleValidate() {


### PR DESCRIPTION
Compressing a brokerpak makes it smaller, but it's hard work for the
processor. During development it can be useful to build brokerpaks
without compression because the speed advantage (it takes less than half
the time to build) outweighs the size advantage.

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* [x] Have you added Draft Release Notes in `docs/draft-release-notes.md`?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

