### PR TITLE
fix: set operation type in instance when updating

### DIFF
--- a/brokerapi/broker/update.go
+++ b/brokerapi/broker/update.go
@@ -177,9 +177,12 @@ func (broker *ServiceBroker) doUpdate(ctx context.Context, serviceProvider broke
 	// save instance plan change
 	if instance.PlanGUID != parsedDetails.PlanID {
 		instance.PlanGUID = parsedDetails.PlanID
-		if err := broker.store.StoreServiceInstanceDetails(instance); err != nil {
-			return domain.UpdateServiceSpec{}, fmt.Errorf("error saving instance details to database: %s. WARNING: this instance cannot be deprovisioned through cf. Contact your operator for cleanup", err)
-		}
+	}
+
+	instance.OperationType = instanceDetails.OperationType
+	instance.OperationGUID = instanceDetails.OperationID
+	if err := broker.store.StoreServiceInstanceDetails(instance); err != nil {
+		return domain.UpdateServiceSpec{}, fmt.Errorf("error saving instance details to database: %s. WARNING: this instance cannot be deprovisioned through cf. Contact your operator for cleanup", err)
 	}
 
 	// save provision request details

--- a/brokerapi/broker/update_test.go
+++ b/brokerapi/broker/update_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Update", func() {
 				}
 			})
 
-			It("should complete without changing instance", func() {
+			It("should complete changing the instance operation type", func() {
 				expectedHeader := "cloudfoundry eyANCiAgInVzZXJfaWQiOiAiNjgzZWE3NDgtMzA5Mi00ZmY0LWI2NTYtMzljYWNjNGQ1MzYwIg0KfQ=="
 				newContext := context.WithValue(context.Background(), middlewares.OriginatingIdentityKey, expectedHeader)
 
@@ -199,8 +199,16 @@ var _ = Describe("Update", func() {
 				actualContext, _ := fakeServiceProvider.UpdateArgsForCall(0)
 				Expect(actualContext.Value(middlewares.OriginatingIdentityKey)).To(Equal(expectedHeader))
 
-				By("validating SI details is not updated")
-				Expect(fakeStorage.StoreServiceInstanceDetailsCallCount()).To(Equal(0))
+				By("validating SI details is updated")
+				storeServiceInstanceDetailsValidation(
+					fakeStorage,
+					updateOperationID,
+					instanceID,
+					offeringID,
+					originalPlanID,
+					spaceID,
+					orgID,
+				)
 
 				By("validating provision parameters storing call")
 				Expect(fakeStorage.StoreProvisionRequestDetailsCallCount()).To(Equal(1))
@@ -249,13 +257,15 @@ var _ = Describe("Update", func() {
 				Expect(fakeServiceProvider.UpdateCallCount()).To(Equal(1))
 
 				By("validating SI details storing call")
-				Expect(fakeStorage.StoreServiceInstanceDetailsCallCount()).To(Equal(1))
-				actualSIDetails := fakeStorage.StoreServiceInstanceDetailsArgsForCall(0)
-				Expect(actualSIDetails.GUID).To(Equal(instanceID))
-				Expect(actualSIDetails.ServiceGUID).To(Equal(offeringID))
-				Expect(actualSIDetails.PlanGUID).To(Equal(newPlanID))
-				Expect(actualSIDetails.SpaceGUID).To(Equal(spaceID))
-				Expect(actualSIDetails.OrganizationGUID).To(Equal(orgID))
+				storeServiceInstanceDetailsValidation(
+					fakeStorage,
+					updateOperationID,
+					instanceID,
+					offeringID,
+					newPlanID,
+					spaceID,
+					orgID,
+				)
 			})
 		})
 
@@ -301,8 +311,16 @@ var _ = Describe("Update", func() {
 				Expect(actualVars.GetString("foo")).To(Equal("quz"))
 				Expect(actualVars.GetString("guz")).To(Equal("muz"))
 
-				By("validating SI details is not updated")
-				Expect(fakeStorage.StoreServiceInstanceDetailsCallCount()).To(Equal(0))
+				By("validating SI details is updated")
+				storeServiceInstanceDetailsValidation(
+					fakeStorage,
+					updateOperationID,
+					instanceID,
+					offeringID,
+					originalPlanID,
+					spaceID,
+					orgID,
+				)
 
 				By("validating provision details have been stored")
 				Expect(fakeStorage.StoreProvisionRequestDetailsCallCount()).To(Equal(1))
@@ -319,6 +337,9 @@ var _ = Describe("Update", func() {
 			It("should error and not update the provision variables", func() {
 				_, err := serviceBroker.Update(context.TODO(), instanceID, updateDetails, true)
 				Expect(err).To(MatchError("cannot update right now"))
+
+				By("validate it does not update the instance details")
+				Expect(fakeStorage.StoreServiceInstanceDetailsCallCount()).To(Equal(0))
 
 				By("validate it does not update the provision request details")
 				Expect(fakeStorage.StoreProvisionRequestDetailsCallCount()).To(Equal(0))
@@ -809,3 +830,23 @@ var _ = Describe("Update", func() {
 		})
 	})
 })
+
+func storeServiceInstanceDetailsValidation(
+	fakeStorage *brokerfakes.FakeStorage,
+	operationGUID,
+	instanceID,
+	offeringID,
+	newPlanID,
+	spaceID,
+	orgID string,
+) {
+	Expect(fakeStorage.StoreServiceInstanceDetailsCallCount()).To(Equal(1))
+	actualServiceInstanceDetails := fakeStorage.StoreServiceInstanceDetailsArgsForCall(0)
+	Expect(actualServiceInstanceDetails.OperationType).To(Equal("update"))
+	Expect(actualServiceInstanceDetails.OperationGUID).To(Equal(operationGUID))
+	Expect(actualServiceInstanceDetails.GUID).To(Equal(instanceID))
+	Expect(actualServiceInstanceDetails.ServiceGUID).To(Equal(offeringID))
+	Expect(actualServiceInstanceDetails.PlanGUID).To(Equal(newPlanID))
+	Expect(actualServiceInstanceDetails.SpaceGUID).To(Equal(spaceID))
+	Expect(actualServiceInstanceDetails.OrganizationGUID).To(Equal(orgID))
+}


### PR DESCRIPTION
After executing a `deprovision` operation whose result was not satisfactory, the type of the last operation performed in the instance was stored in the database, that is, OperationType = deprovision, as established by the business logic. If after the `deprovision` operation, we performed an operation of updating a property of the same instance, for example modifying the property `deletion_protection` in some of the database services of some of the providers, the type of the last operation performed in the instance was not stored, that is, we did not assign the value `update` to the type of the last operation performed in the instance.

After a new call to endpoint /v2/service_instances/:instance_id/last_operation due to an asynchronous operation, the logic associated with this endpoint deleted the instance.

Steps we performed before fixing the problem:

* Deprovision operation executed successfully.
* OperationType = deprovision stored in our database associated with the instance.
* Update operation executed successfully in asynchronous mode.
* OperationType = update was not stored in our database. Instance with an incorrect state.
* LastOperation operation check executed successfully. Last OperationType = deprovision instead of update.
* Logic associated with deleting instance executed successfully.

[#183452044](https://www.pivotaltracker.com/story/show/183452044)

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* [x] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

