### PR TITLE
fix: make config parsing sane

### DIFF
--- a/pkg/varcontext/interpolation/assets/example-config.yml
+++ b/pkg/varcontext/interpolation/assets/example-config.yml
@@ -1,0 +1,8 @@
+test:
+  object: {"value": "one"}
+  map:
+    value: one
+  string_object: '{"value":"one"}'
+  string_multiline_object: |
+    {"value":"one"}
+

--- a/pkg/varcontext/interpolation/eval_test.go
+++ b/pkg/varcontext/interpolation/eval_test.go
@@ -33,38 +33,44 @@ func TestEval(t *testing.T) {
 		Expected      any
 		ErrorContains string
 	}{
-		"Non-Templated String":  {Template: "foo", Expected: "foo"},
-		"Basic Evaluation":      {Template: "${33}", Expected: "33"},
-		"Escaped Evaluation":    {Template: "$${33}", Expected: "${33}"},
-		"Missing Variable":      {Template: "${a}", ErrorContains: "unknown variable accessed: a"},
-		"Variable Substitution": {Template: "${foo}", Variables: map[string]any{"foo": 33}, Expected: "33"},
-		"Bad Template":          {Template: "${", ErrorContains: "expected expression"},
-		"Truncate Required":     {Template: `${str.truncate(2, "expression")}`, Expected: "ex"},
-		"Truncate Not Required": {Template: `${str.truncate(200, "expression")}`, Expected: "expression"},
-		"Counter":               {Template: "${counter.next()},${counter.next()},${counter.next()}", Expected: "1,2,3"},
-		"Query Escape":          {Template: `${str.queryEscape("hello world")}`, Expected: "hello+world"},
-		"Query Amp":             {Template: `${str.queryEscape("hello&world")}`, Expected: "hello%26world"},
-		"Regex":                 {Template: `${regexp.matches("^(D|d)[0-9]+$", "d12345")}`, Expected: "true"},
-		"Bad Regex":             {Template: `${regexp.matches("^($", "d12345")}`, ErrorContains: "error parsing regexp"},
-		"Conditionals True":     {Template: `${true ? "foo" : "bar"}`, Expected: "foo"},
-		"Conditionals False":    {Template: `${false ? "foo" : "bar"}`, Expected: "bar"},
-		"No Short Circuit":      {Template: `${false ? counter.next() : counter.next()}`, Expected: "2"},
-		"assert success":        {Template: `${assert(true, "nothing should happen")}`, Expected: "true"},
-		"assert failure":        {Template: `${assert(false, "failure message")}`, ErrorContains: "failure message"},
-		"assert message":        {Template: `${assert(false, "failure message ${1+1}")}`, ErrorContains: "failure message 2"},
-		"json marshal":          {Template: "${json.marshal(mapval)}", Variables: map[string]any{"mapval": map[string]string{"hello": "world"}}, Expected: `{"hello":"world"}`},
-		"json marshal array":    {Template: "${json.marshal(list)}", Variables: map[string]any{"list": []string{"a", "b", "c"}}, Expected: `["a","b","c"]`},
-		"json marshal numeric":  {Template: "${json.marshal(42)}", Expected: `42`},
-		"json marshal string":   {Template: `${json.marshal("str")}`, Expected: `"str"`},
-		"json marshal true":     {Template: "${json.marshal(true)}", Expected: `true`},
-		"json marshal false":    {Template: "${json.marshal(false)}", Expected: `false`},
-		"map flatten blank":     {Template: `${map.flatten(":", ";", mapval)}`, Variables: map[string]any{"mapval": map[string]string{}}, Expected: ``},
-		"map flatten one":       {Template: `${map.flatten(":", ";", mapval)}`, Variables: map[string]any{"mapval": map[string]string{"key1": "val1"}}, Expected: `key1:val1`},
-		"map flatten":           {Template: `${map.flatten(":", ";", mapval)}`, Variables: map[string]any{"mapval": map[string]string{"key1": "val1", "key2": "val2"}}, Expected: `key1:val1;key2:val2`},
-		"env var":               {Template: `${env("FOO")}`, Expected: `Bar`},
-		"missing env var":       {Template: `${env("_MISSING")}`, ErrorContains: "missing environment variable _MISSING"},
-		"config val":            {Template: `${config("config.val")}`, Expected: `foo`},
-		"missing config var":    {Template: `${config("config.missing")}`, ErrorContains: "missing config value config.missing"},
+		"Non-Templated String":               {Template: "foo", Expected: "foo"},
+		"Basic Evaluation":                   {Template: "${33}", Expected: "33"},
+		"Escaped Evaluation":                 {Template: "$${33}", Expected: "${33}"},
+		"Missing Variable":                   {Template: "${a}", ErrorContains: "unknown variable accessed: a"},
+		"Variable Substitution":              {Template: "${foo}", Variables: map[string]any{"foo": 33}, Expected: "33"},
+		"Bad Template":                       {Template: "${", ErrorContains: "expected expression"},
+		"Truncate Required":                  {Template: `${str.truncate(2, "expression")}`, Expected: "ex"},
+		"Truncate Not Required":              {Template: `${str.truncate(200, "expression")}`, Expected: "expression"},
+		"Counter":                            {Template: "${counter.next()},${counter.next()},${counter.next()}", Expected: "1,2,3"},
+		"Query Escape":                       {Template: `${str.queryEscape("hello world")}`, Expected: "hello+world"},
+		"Query Amp":                          {Template: `${str.queryEscape("hello&world")}`, Expected: "hello%26world"},
+		"Regex":                              {Template: `${regexp.matches("^(D|d)[0-9]+$", "d12345")}`, Expected: "true"},
+		"Bad Regex":                          {Template: `${regexp.matches("^($", "d12345")}`, ErrorContains: "error parsing regexp"},
+		"Conditionals True":                  {Template: `${true ? "foo" : "bar"}`, Expected: "foo"},
+		"Conditionals False":                 {Template: `${false ? "foo" : "bar"}`, Expected: "bar"},
+		"No Short Circuit":                   {Template: `${false ? counter.next() : counter.next()}`, Expected: "2"},
+		"assert success":                     {Template: `${assert(true, "nothing should happen")}`, Expected: "true"},
+		"assert failure":                     {Template: `${assert(false, "failure message")}`, ErrorContains: "failure message"},
+		"assert message":                     {Template: `${assert(false, "failure message ${1+1}")}`, ErrorContains: "failure message 2"},
+		"json marshal":                       {Template: "${json.marshal(mapval)}", Variables: map[string]any{"mapval": map[string]string{"hello": "world"}}, Expected: `{"hello":"world"}`},
+		"json marshal array":                 {Template: "${json.marshal(list)}", Variables: map[string]any{"list": []string{"a", "b", "c"}}, Expected: `["a","b","c"]`},
+		"json marshal numeric":               {Template: "${json.marshal(42)}", Expected: `42`},
+		"json marshal string":                {Template: `${json.marshal("str")}`, Expected: `"str"`},
+		"json marshal true":                  {Template: "${json.marshal(true)}", Expected: `true`},
+		"json marshal false":                 {Template: "${json.marshal(false)}", Expected: `false`},
+		"map flatten blank":                  {Template: `${map.flatten(":", ";", mapval)}`, Variables: map[string]any{"mapval": map[string]string{}}, Expected: ``},
+		"map flatten one":                    {Template: `${map.flatten(":", ";", mapval)}`, Variables: map[string]any{"mapval": map[string]string{"key1": "val1"}}, Expected: `key1:val1`},
+		"map flatten":                        {Template: `${map.flatten(":", ";", mapval)}`, Variables: map[string]any{"mapval": map[string]string{"key1": "val1", "key2": "val2"}}, Expected: `key1:val1;key2:val2`},
+		"env var":                            {Template: `${env("FOO")}`, Expected: `Bar`},
+		"missing env var":                    {Template: `${env("_MISSING")}`, ErrorContains: "missing environment variable _MISSING"},
+		"config val":                         {Template: `${config("config.val")}`, Expected: `foo`},
+		"config val nested map":              {Template: `${config("test.map")}`, Expected: `{"value":"one"}`},
+		"config val nested map nested value": {Template: `${config("test.map.value")}`, Expected: `one`},
+		"config val nested json object":      {Template: `${config("test.object")}`, Expected: `{"value":"one"}`},
+		"config val nested json object nested value": {Template: `${config("test.object.value")}`, Expected: `one`},
+		"config val nested string object":            {Template: `${config("test.string_object")}`, Expected: `{"value":"one"}`},
+		"config val nested multiline string object":  {Template: `${config("test.string_multiline_object")}`, Expected: `{"value":"one"}`},
+		"missing config var":                         {Template: `${config("config.missing")}`, ErrorContains: "missing config value config.missing"},
 	}
 
 	for tn, tc := range tests {
@@ -72,6 +78,8 @@ func TestEval(t *testing.T) {
 
 		os.Setenv("FOO", "Bar")
 		defer os.Unsetenv("FOO")
+		viper.SetConfigFile("assets/example-config.yml")
+		viper.ReadInConfig()
 		viper.SetDefault("config.val", "foo")
 
 		t.Run(tn, func(t *testing.T) {
@@ -83,11 +91,11 @@ func TestEval(t *testing.T) {
 			}
 
 			if expectingErr && !strings.Contains(err.Error(), tc.ErrorContains) {
-				t.Errorf("Expected error: %v to contain %q", err, tc.ErrorContains)
+				t.Errorf("Case: %v Expected error: %v to contain %q", tn, err, tc.ErrorContains)
 			}
 
 			if !reflect.DeepEqual(tc.Expected, res) {
-				t.Errorf("Expected result: %+v, got %+v", tc.Expected, res)
+				t.Errorf("Case: %v Expected result: '%+v', got '%+v'", tn, tc.Expected, res)
 			}
 		})
 	}

--- a/pkg/varcontext/interpolation/funcs.go
+++ b/pkg/varcontext/interpolation/funcs.go
@@ -59,8 +59,18 @@ func hilFuncConfig() ast.Function {
 		ArgTypes:   []ast.Type{ast.TypeString},
 		ReturnType: ast.TypeString,
 		Callback: func(args []any) (any, error) {
-			if viper.IsSet(args[0].(string)) {
-				return viper.GetString(args[0].(string)), nil
+
+			key := args[0].(string)
+			if viper.IsSet(key) {
+				val := viper.Get(key)
+				// Check If we're handling a nested object
+				if mapVal, ok := val.(map[string]interface{}); ok {
+					bytes, err := json.Marshal(mapVal)
+					// return string representation of the object contents
+					return string(bytes), err
+				}
+				// return string and remove leading/trailing whitespace
+				return strings.TrimSpace(val.(string)), nil
 			}
 			return "", fmt.Errorf("missing config value %s", args[0].(string))
 		},


### PR DESCRIPTION
if the broker uses a brokerpak that in turn uses
`${config("yaml.path.to.item")} HIL funtion, configs can only be parsed when the yaml value for `yaml.path.to.item` is a string. e.g.:

this will work
```
yaml.path.to.item: '{"key":"value"}'
```

this wont:

```
yaml.path.to.item: {"key":"value"}
```

this neither

```
yaml.path.to.item:
  key: value
```

we should support passing in valid yaml and json configuration via config files for items referenced via the hil func config.

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* ~[ ] Have you added Release Notes in the docs repositories?~
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

