### PR TITLE
test: testdrive should return matchable errors

### DIFF
--- a/internal/testdrive/broker_create_binding.go
+++ b/internal/testdrive/broker_create_binding.go
@@ -2,7 +2,6 @@ package testdrive
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/cloudfoundry/cloud-service-broker/pkg/client"
@@ -38,7 +37,7 @@ func (b *Broker) CreateBinding(s ServiceInstance, opts ...CreateBindingOption) (
 	case bindResponse.Error != nil:
 		return ServiceBinding{}, bindResponse.Error
 	case bindResponse.StatusCode != http.StatusCreated:
-		return ServiceBinding{}, fmt.Errorf("unexpected status code %d: %s", bindResponse.StatusCode, bindResponse.ResponseBody)
+		return ServiceBinding{}, &UnexpectedStatusError{StatusCode: bindResponse.StatusCode, ResponseBody: bindResponse.ResponseBody}
 	default:
 		return ServiceBinding{
 			GUID: cfg.guid,

--- a/internal/testdrive/broker_delete_binding.go
+++ b/internal/testdrive/broker_delete_binding.go
@@ -1,7 +1,6 @@
 package testdrive
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/pborman/uuid"
@@ -13,7 +12,7 @@ func (b *Broker) DeleteBinding(s ServiceInstance, serviceBindingGUID string) err
 	case unbindResponse.Error != nil:
 		return unbindResponse.Error
 	case unbindResponse.StatusCode != http.StatusOK:
-		return fmt.Errorf("unexpected status code %d: %s", unbindResponse.StatusCode, unbindResponse.ResponseBody)
+		return &UnexpectedStatusError{StatusCode: unbindResponse.StatusCode, ResponseBody: unbindResponse.ResponseBody}
 	default:
 		return nil
 	}

--- a/internal/testdrive/broker_deprovision.go
+++ b/internal/testdrive/broker_deprovision.go
@@ -14,7 +14,7 @@ func (b *Broker) Deprovision(s ServiceInstance) error {
 	case deprovisionResponse.Error != nil:
 		return deprovisionResponse.Error
 	case deprovisionResponse.StatusCode != http.StatusAccepted:
-		return fmt.Errorf("unexpected status code %d: %s", deprovisionResponse.StatusCode, deprovisionResponse.ResponseBody)
+		return &UnexpectedStatusError{StatusCode: deprovisionResponse.StatusCode, ResponseBody: deprovisionResponse.ResponseBody}
 	}
 
 	state, err := b.LastOperationFinalState(s.GUID)

--- a/internal/testdrive/broker_last_operation.go
+++ b/internal/testdrive/broker_last_operation.go
@@ -16,7 +16,7 @@ func (b *Broker) LastOperation(serviceInstanceGUID string) (domain.LastOperation
 	case lastOperationResponse.Error != nil:
 		return domain.LastOperation{}, lastOperationResponse.Error
 	case lastOperationResponse.StatusCode != http.StatusOK:
-		return domain.LastOperation{}, fmt.Errorf("expected status code %d: %s", lastOperationResponse.StatusCode, lastOperationResponse.ResponseBody)
+		return domain.LastOperation{}, &UnexpectedStatusError{StatusCode: lastOperationResponse.StatusCode, ResponseBody: lastOperationResponse.ResponseBody}
 	}
 
 	var receiver domain.LastOperation

--- a/internal/testdrive/broker_provision.go
+++ b/internal/testdrive/broker_provision.go
@@ -38,7 +38,7 @@ func (b *Broker) Provision(serviceOfferingGUID, servicePlanGUID string, opts ...
 			case provisionResponse.Error != nil:
 				return provisionResponse.Error
 			case provisionResponse.StatusCode != http.StatusAccepted:
-				return fmt.Errorf("unexpected status code %d: %s", provisionResponse.StatusCode, provisionResponse.ResponseBody)
+				return &UnexpectedStatusError{StatusCode: provisionResponse.StatusCode, ResponseBody: provisionResponse.ResponseBody}
 			default:
 				return nil
 			}

--- a/internal/testdrive/broker_update.go
+++ b/internal/testdrive/broker_update.go
@@ -36,7 +36,7 @@ func (b *Broker) UpdateService(s ServiceInstance, opts ...UpdateOption) error {
 			case updateResponse.Error != nil:
 				return updateResponse.Error
 			case updateResponse.StatusCode != http.StatusAccepted:
-				return fmt.Errorf("unexpected status code %d: %s", updateResponse.StatusCode, updateResponse.ResponseBody)
+				return &UnexpectedStatusError{StatusCode: updateResponse.StatusCode, ResponseBody: updateResponse.ResponseBody}
 			default:
 				return nil
 			}

--- a/internal/testdrive/broker_upgrade.go
+++ b/internal/testdrive/broker_upgrade.go
@@ -34,7 +34,7 @@ func (b *Broker) UpgradeService(s ServiceInstance, version string, opts ...Upgra
 			case updateResponse.Error != nil:
 				return updateResponse.Error
 			case updateResponse.StatusCode != http.StatusAccepted:
-				return fmt.Errorf("unexpected status code %d: %s", updateResponse.StatusCode, updateResponse.ResponseBody)
+				return &UnexpectedStatusError{StatusCode: updateResponse.StatusCode, ResponseBody: updateResponse.ResponseBody}
 			default:
 				return nil
 			}

--- a/internal/testdrive/error.go
+++ b/internal/testdrive/error.go
@@ -1,0 +1,12 @@
+package testdrive
+
+import "fmt"
+
+type UnexpectedStatusError struct {
+	StatusCode   int
+	ResponseBody []byte
+}
+
+func (u *UnexpectedStatusError) Error() string {
+	return fmt.Sprintf("unexpected status code %d: %s", u.StatusCode, u.ResponseBody)
+}


### PR DESCRIPTION
By returning custom errors, it's possible to match against status code and body, rather than relying on string matching of the rendered error.

[#183405838](https://www.pivotaltracker.com/story/show/183405838)
