### PR TITLE
fix: return HTTP 410 when deleting non-existent binding

### DIFF
--- a/brokerapi/broker/bind_test.go
+++ b/brokerapi/broker/bind_test.go
@@ -228,7 +228,7 @@ var _ = Describe("Bind", func() {
 				fakeStorage.ExistsServiceBindingCredentialsReturns(true, nil)
 			})
 
-			It("should error", func() {
+			It("should return HTTP 409 as per OSBAPI spec", func() {
 				_, err := serviceBroker.Bind(context.TODO(), instanceID, bindingID, bindDetails, false)
 
 				Expect(err).To(MatchError(apiresponses.ErrBindingAlreadyExists))

--- a/brokerapi/broker/deprovision_test.go
+++ b/brokerapi/broker/deprovision_test.go
@@ -5,12 +5,6 @@ import (
 	"fmt"
 
 	"code.cloudfoundry.org/lager"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v8/domain"
-	"github.com/pivotal-cf/brokerapi/v8/middlewares"
-	"golang.org/x/net/context"
-
 	"github.com/cloudfoundry/cloud-service-broker/brokerapi/broker"
 	"github.com/cloudfoundry/cloud-service-broker/brokerapi/broker/brokerfakes"
 	"github.com/cloudfoundry/cloud-service-broker/dbservice/models"
@@ -19,6 +13,12 @@ import (
 	pkgBrokerFakes "github.com/cloudfoundry/cloud-service-broker/pkg/broker/brokerfakes"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/varcontext"
 	"github.com/cloudfoundry/cloud-service-broker/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+	"github.com/pivotal-cf/brokerapi/v8/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v8/middlewares"
+	"golang.org/x/net/context"
 )
 
 var _ = Describe("Deprovision", func() {
@@ -216,9 +216,9 @@ var _ = Describe("Deprovision", func() {
 			fakeStorage.ExistsServiceInstanceDetailsReturns(false, nil)
 		})
 
-		It("should error", func() {
+		It("should return HTTP 410 as per OSBAPI spec", func() {
 			_, err := serviceBroker.Deprovision(context.TODO(), instanceToDeleteID, deprovisionDetails, true)
-			Expect(err).To(MatchError("instance does not exist"))
+			Expect(err).To(MatchError(apiresponses.ErrInstanceDoesNotExist))
 		})
 	})
 

--- a/brokerapi/broker/last_instance_operation_test.go
+++ b/brokerapi/broker/last_instance_operation_test.go
@@ -4,12 +4,6 @@ import (
 	"errors"
 
 	"code.cloudfoundry.org/lager"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v8/domain"
-	"github.com/pivotal-cf/brokerapi/v8/middlewares"
-	"golang.org/x/net/context"
-
 	"github.com/cloudfoundry/cloud-service-broker/brokerapi/broker"
 	"github.com/cloudfoundry/cloud-service-broker/brokerapi/broker/brokerfakes"
 	"github.com/cloudfoundry/cloud-service-broker/dbservice/models"
@@ -17,6 +11,12 @@ import (
 	pkgBroker "github.com/cloudfoundry/cloud-service-broker/pkg/broker"
 	pkgBrokerFakes "github.com/cloudfoundry/cloud-service-broker/pkg/broker/brokerfakes"
 	"github.com/cloudfoundry/cloud-service-broker/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+	"github.com/pivotal-cf/brokerapi/v8/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v8/middlewares"
+	"golang.org/x/net/context"
 )
 
 var _ = Describe("LastInstanceOperation", func() {
@@ -284,6 +284,17 @@ var _ = Describe("LastInstanceOperation", func() {
 				Expect(result.State).To(Equal(domain.Succeeded))
 				Expect(result.Description).To(Equal("operation complete"))
 			})
+		})
+	})
+
+	Describe("service instance does not exist", func() {
+		BeforeEach(func() {
+			fakeStorage.GetServiceInstanceDetailsReturns(storage.ServiceInstanceDetails{}, errors.New("does not exist"))
+		})
+
+		It("should return HTTP 410 as per OSBAPI spec", func() {
+			_, err := serviceBroker.LastOperation(context.TODO(), instanceID, pollDetails)
+			Expect(err).To(Equal(apiresponses.ErrInstanceDoesNotExist))
 		})
 	})
 })

--- a/brokerapi/broker/provision_test.go
+++ b/brokerapi/broker/provision_test.go
@@ -7,12 +7,6 @@ import (
 	"fmt"
 
 	"code.cloudfoundry.org/lager"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/pivotal-cf/brokerapi/v8/domain"
-	"github.com/pivotal-cf/brokerapi/v8/middlewares"
-	"github.com/spf13/viper"
-
 	"github.com/cloudfoundry/cloud-service-broker/brokerapi/broker"
 	"github.com/cloudfoundry/cloud-service-broker/brokerapi/broker/brokerfakes"
 	"github.com/cloudfoundry/cloud-service-broker/dbservice/models"
@@ -22,6 +16,12 @@ import (
 	"github.com/cloudfoundry/cloud-service-broker/pkg/featureflags"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/varcontext"
 	"github.com/cloudfoundry/cloud-service-broker/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+	"github.com/pivotal-cf/brokerapi/v8/domain/apiresponses"
+	"github.com/pivotal-cf/brokerapi/v8/middlewares"
+	"github.com/spf13/viper"
 )
 
 var _ = Describe("Provision", func() {
@@ -268,9 +268,9 @@ var _ = Describe("Provision", func() {
 			fakeStorage.ExistsServiceInstanceDetailsReturns(true, nil)
 		})
 
-		It("should error", func() {
+		It("should return HTTP 409 as per OSBAPI spec", func() {
 			_, err := serviceBroker.Provision(context.TODO(), "new-instance", provisionDetails, true)
-			Expect(err).To(MatchError("instance already exists"))
+			Expect(err).To(MatchError(apiresponses.ErrInstanceAlreadyExists))
 		})
 	})
 

--- a/brokerapi/broker/unbind_test.go
+++ b/brokerapi/broker/unbind_test.go
@@ -210,7 +210,7 @@ var _ = Describe("Unbind", func() {
 	})
 
 	Describe("unsuccessful unbind", func() {
-		When("error validating the service exists", func() {
+		When("service offering does not exists", func() {
 			const nonExistentService = "non-existent-service"
 
 			BeforeEach(func() {
@@ -234,7 +234,7 @@ var _ = Describe("Unbind", func() {
 			})
 		})
 
-		When("error validating the plan exists", func() {
+		When("error validating the service plan exists", func() {
 			const nonExistentPlan = "non-existent-plan"
 
 			BeforeEach(func() {
@@ -253,7 +253,7 @@ var _ = Describe("Unbind", func() {
 				fakeStorage.ExistsServiceBindingCredentialsReturns(false, nil)
 			})
 
-			It("should error", func() {
+			It("should return HTTP 410 as per OSBAPI spec", func() {
 				_, err := serviceBroker.Unbind(context.TODO(), instanceID, bindingID, unbindDetails, false)
 
 				Expect(err).To(MatchError(apiresponses.ErrBindingDoesNotExist))
@@ -277,10 +277,10 @@ var _ = Describe("Unbind", func() {
 				fakeStorage.GetServiceInstanceDetailsReturns(storage.ServiceInstanceDetails{}, fmt.Errorf("error"))
 			})
 
-			It("should error", func() {
+			It("should return HTTP 410 as per OSBAPI spec", func() {
 				_, err := serviceBroker.Unbind(context.TODO(), instanceID, bindingID, unbindDetails, false)
 
-				Expect(err).To(MatchError("error retrieving service instance details: error"))
+				Expect(err).To(MatchError(apiresponses.ErrInstanceDoesNotExist))
 			})
 		})
 

--- a/integrationtest/fixtures/osbapi/fake-provision.tf
+++ b/integrationtest/fixtures/osbapi/fake-provision.tf
@@ -1,0 +1,6 @@
+provider "random" { }
+
+resource "random_integer" "priority" {
+  min = 1
+  max = 100
+}

--- a/integrationtest/fixtures/osbapi/fake-service.yml
+++ b/integrationtest/fixtures/osbapi/fake-service.yml
@@ -1,0 +1,19 @@
+version: 1
+name: fake-service
+id: df2c1512-3013-11ec-8704-2fbfa9c8a802
+description: description
+display_name: Fake
+image_url: https://example.com/icon.jpg
+documentation_url: https://example.com
+support_url: https://example.com/support.html
+plans:
+- name: first
+  id: e59773ce-3013-11ec-9bbb-9376b4f72d14
+  description: First plan
+  display_name: First
+provision:
+  template_refs:
+    main: fake-provision.tf
+bind:
+  template_refs:
+    main: fake-provision.tf

--- a/integrationtest/fixtures/osbapi/manifest.yml
+++ b/integrationtest/fixtures/osbapi/manifest.yml
@@ -1,0 +1,17 @@
+packversion: 1
+name: fake-brokerpak
+version: 0.1.0
+metadata:
+  author: noone@nowhere.com
+platforms:
+- os: linux
+  arch: amd64
+- os: darwin
+  arch: amd64
+terraform_binaries:
+- name: terraform
+  version: 0.12.21
+- name: terraform-provider-random
+  version: 2.2.1
+service_definitions:
+- fake-service.yml

--- a/integrationtest/osbapi_test.go
+++ b/integrationtest/osbapi_test.go
@@ -1,0 +1,113 @@
+package integrationtest_test
+
+import (
+	"net/http"
+
+	"github.com/cloudfoundry/cloud-service-broker/integrationtest/packer"
+	"github.com/cloudfoundry/cloud-service-broker/internal/testdrive"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+)
+
+var _ = Describe("OSBAPI spec", func() {
+	const (
+		serviceOfferingGUID = "df2c1512-3013-11ec-8704-2fbfa9c8a802"
+		servicePlanGUID     = "e59773ce-3013-11ec-9bbb-9376b4f72d14"
+	)
+
+	var broker *testdrive.Broker
+
+	BeforeEach(func() {
+		brokerpak := must(packer.BuildBrokerpak(csb, fixtures("osbapi")))
+		broker = must(testdrive.StartBroker(csb, brokerpak, database, testdrive.WithOutputs(GinkgoWriter, GinkgoWriter)))
+
+		DeferCleanup(func() {
+			Expect(broker.Stop()).To(Succeed())
+			cleanup(brokerpak)
+		})
+	})
+
+	When("a service instance does not exist", func() {
+		Context("service instance last operation", func() {
+			It("returns HTTP 410 as per OSBAPI spec", func() {
+				_, err := broker.LastOperation("does-not-exist")
+
+				Expect(err).To(matchUnexpectedStatusError(http.StatusGone, "{}"))
+			})
+		})
+
+		Context("delete service instance", func() {
+			It("returns HTTP 410 as per OSBAPI spec", func() {
+				err := broker.Deprovision(testdrive.ServiceInstance{
+					GUID:                "does-not-exist",
+					ServicePlanGUID:     servicePlanGUID,
+					ServiceOfferingGUID: serviceOfferingGUID,
+				})
+
+				Expect(err).To(matchUnexpectedStatusError(http.StatusGone, "{}"))
+			})
+		})
+
+		Context("delete service binding", func() {
+			It("returns HTTP 410 as per OSBAPI spec", func() {
+				err := broker.DeleteBinding(testdrive.ServiceInstance{
+					GUID:                "does-not-exist",
+					ServicePlanGUID:     servicePlanGUID,
+					ServiceOfferingGUID: serviceOfferingGUID,
+				}, "does-not-exist")
+
+				Expect(err).To(matchUnexpectedStatusError(http.StatusGone, "{}"))
+			})
+		})
+	})
+
+	When("a service instance exists", func() {
+		var serviceInstance testdrive.ServiceInstance
+
+		BeforeEach(func() {
+			serviceInstance = must(broker.Provision(serviceOfferingGUID, servicePlanGUID))
+		})
+
+		Context("provision instance with same GUID", func() {
+			It("returns HTTP 409 as per OSBAPI spec", func() {
+				_, err := broker.Provision(serviceOfferingGUID, servicePlanGUID, testdrive.WithProvisionServiceInstanceGUID(serviceInstance.GUID))
+				Expect(err).To(matchUnexpectedStatusError(http.StatusConflict, "{}"))
+			})
+		})
+
+		When("a service binding does not exist", func() {
+			Context("delete service binding", func() {
+				It("returns HTTP 410 as per OSBAPI spec", func() {
+					err := broker.DeleteBinding(serviceInstance, "does-not-exist")
+
+					Expect(err).To(matchUnexpectedStatusError(http.StatusGone, "{}"))
+				})
+			})
+		})
+
+		When("a service binding exists", func() {
+			var binding testdrive.ServiceBinding
+
+			BeforeEach(func() {
+				binding = must(broker.CreateBinding(serviceInstance))
+			})
+
+			Context("create binding with same GUID", func() {
+				It("returns HTTP 409 as per OSBAPI spec", func() {
+					_, err := broker.CreateBinding(serviceInstance, testdrive.WithBindingGUID(binding.GUID))
+
+					Expect(err).To(matchUnexpectedStatusError(http.StatusConflict, `{"description":"binding already exists"}`))
+				})
+			})
+		})
+	})
+})
+
+func matchUnexpectedStatusError(code int, body string) types.GomegaMatcher {
+	return gstruct.PointTo(gstruct.MatchAllFields(gstruct.Fields{
+		"StatusCode":   Equal(code),
+		"ResponseBody": MatchJSON(body),
+	}))
+}


### PR DESCRIPTION
The Open Service Broker API (OSBAPI) spec says that an HTTP 410 should be returned when trying to delete a binding that does not exist.

[#183405838](https://www.pivotaltracker.com/story/show/183405838)