### PR TITLE
test: failures to start the broker should not cause panic

### DIFF
--- a/internal/testdrive/broker.go
+++ b/internal/testdrive/broker.go
@@ -19,8 +19,8 @@ type Broker struct {
 }
 
 func (b *Broker) Stop() error {
-	switch b.runner {
-	case nil:
+	switch {
+	case b == nil, b.runner == nil:
 		return nil
 	default:
 		return b.runner.stop()


### PR DESCRIPTION
When the broker fails to start in a test (often an error that we are in the process of testing), we occasionally get a panic from the test framework.
