### PR TITLE
fix: dev command "csb services" should succeed with emtpty DB

### DIFF
--- a/dbservice/dbservice.go
+++ b/dbservice/dbservice.go
@@ -33,7 +33,7 @@ func New(logger lager.Logger) *gorm.DB {
 	once.Do(func() {
 		db = SetupDB(logger)
 		if err := RunMigrations(db); err != nil {
-			panic(fmt.Sprintf("Error migrating database: %s", err.Error()))
+			panic(fmt.Sprintf("Error migrating database: %s", err))
 		}
 	})
 	return db


### PR DESCRIPTION
If the "csb services" command was run with an empty DB, it failed because the database tables had not been created yet. They are now created after the first DB connection.