### PR TITLE
feat: example tests automatically start broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ The mimic commands build a brokerpak, start an ephemeral CSB server and send OSB
 requests to it in a similar style to what CloudFoundry would do. The CSB database
 is stored as a file called `.csb.db`.
 
+Additionally, there are commands which use the same framework to run the example tests. These are:
+- `csb examples` - list the example tests
+- `csb run-examples` - runs the specified example tests
+
 
 ## Bug Reports, Feature Requests, Documentation Requests & Support
 

--- a/cmd/local.go
+++ b/cmd/local.go
@@ -1,16 +1,16 @@
 package cmd
 
 import (
+	"log"
+
 	"github.com/cloudfoundry/cloud-service-broker/internal/local"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
 func init() {
-	var (
-		params string
-		plan   string
-	)
+	var params, plan, service, example string
+	var all bool
 
 	marketplaceCmd := &cobra.Command{
 		Use:   "marketplace",
@@ -97,4 +97,35 @@ func init() {
 		},
 	}
 	rootCmd.AddCommand(deleteServiceKeyCmd)
+
+	listExamplesCmd := &cobra.Command{
+		Use:   "examples",
+		Short: "EXPERIMENTAL AND SUBJECT TO BREAKING CHANGE: list example tests",
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			local.ListExamples(viper.GetString(pakCachePath))
+		},
+	}
+	rootCmd.AddCommand(listExamplesCmd)
+
+	const (
+		serviceFlag = "service-name"
+		exampleFlag = "example-name"
+		allFlag     = "all"
+	)
+	runExamplesCmd := &cobra.Command{
+		Use:   "run-examples",
+		Short: "EXPERIMENTAL AND SUBJECT TO BREAKING CHANGE: run example tests",
+		Args:  cobra.ExactArgs(0),
+		Run: func(cmd *cobra.Command, args []string) {
+			if !all && service == "" && example == "" {
+				log.Fatalln("specify --service-name and/or --example-name, or --all to run all the tests")
+			}
+			local.RunExamples(service, example, viper.GetString(pakCachePath))
+		},
+	}
+	runExamplesCmd.Flags().StringVarP(&service, serviceFlag, "s", "", "service offering name")
+	runExamplesCmd.Flags().StringVarP(&example, exampleFlag, "e", "", "example test name")
+	runExamplesCmd.Flags().BoolVarP(&all, allFlag, "a", false, "run all tests")
+	rootCmd.AddCommand(runExamplesCmd)
 }

--- a/internal/local/list_examples.go
+++ b/internal/local/list_examples.go
@@ -1,0 +1,56 @@
+package local
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"text/tabwriter"
+
+	"github.com/cloudfoundry/cloud-service-broker/pkg/client"
+)
+
+func ListExamples(cachePath string) {
+	pakDir, cleanup := pack(cachePath)
+	defer cleanup()
+
+	broker := startBroker(pakDir)
+	defer broker.Stop()
+
+	examples, err := listExamples(broker.Port)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.StripEscape)
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, "Example Name\tService Offering Name")
+	_, _ = fmt.Fprintln(w, "------------\t---------------------")
+	for _, e := range examples {
+		_, _ = fmt.Fprintf(w, "%s\t%s\n", e.Name, e.ServiceName)
+	}
+	_, _ = fmt.Fprintln(w)
+	_ = w.Flush()
+}
+
+func listExamples(port int) ([]client.CompleteServiceExample, error) {
+	response, err := http.Get(fmt.Sprintf("http://localhost:%d/examples", port))
+	if err != nil {
+		return nil, fmt.Errorf("error getting examples from broker: %w", err)
+	}
+
+	defer response.Body.Close()
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading body: %w", err)
+	}
+
+	var examples []client.CompleteServiceExample
+	if err := json.Unmarshal(data, &examples); err != nil {
+		return nil, fmt.Errorf("error unmarshalling JSON response: %w", err)
+	}
+
+	return examples, nil
+}

--- a/internal/local/run_examples.go
+++ b/internal/local/run_examples.go
@@ -1,0 +1,23 @@
+package local
+
+import (
+	"log"
+
+	"github.com/cloudfoundry/cloud-service-broker/pkg/client"
+)
+
+func RunExamples(serviceOfferingName, exampleName, cachePath string) {
+	pakDir, cleanup := pack(cachePath)
+	defer cleanup()
+
+	broker := startBroker(pakDir)
+	defer broker.Stop()
+
+	examples, err := listExamples(broker.Port)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	const jobCount = 1_000_000
+	client.RunExamplesForService(examples, broker.Client, serviceOfferingName, exampleName, jobCount)
+}


### PR DESCRIPTION
Previously, to run the example tests, one had to start a broker in one terminal, and run the "csb client run-examples" command in another terminal. This feature builds on the CSB local experience and automatically starts the broker for you. The new commands are:

- csb examples (to list examples)
- csb run-examples (to run examples)

This feature is experimental for now, and the old functionality still exists. Assuming the new way works well, we should eventually remove the old way.
