### PR TITLE
chore: factor out table printing

### DIFF
--- a/internal/local/list_examples.go
+++ b/internal/local/list_examples.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"log"
 	"net/http"
-	"os"
-	"text/tabwriter"
 
 	"github.com/cloudfoundry/cloud-service-broker/pkg/client"
 )
@@ -24,15 +22,11 @@ func ListExamples(cachePath string) {
 		log.Fatal(err)
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.StripEscape)
-	_, _ = fmt.Fprintln(w)
-	_, _ = fmt.Fprintln(w, "Example Name\tService Offering Name")
-	_, _ = fmt.Fprintln(w, "------------\t---------------------")
+	tp := newTablePrinter("Example Name", "Service Offering Name")
 	for _, e := range examples {
-		_, _ = fmt.Fprintf(w, "%s\t%s\n", e.Name, e.ServiceName)
+		tp.row(e.Name, e.ServiceName)
 	}
-	_, _ = fmt.Fprintln(w)
-	_ = w.Flush()
+	tp.print()
 }
 
 func listExamples(port int) ([]client.CompleteServiceExample, error) {

--- a/internal/local/services.go
+++ b/internal/local/services.go
@@ -1,10 +1,7 @@
 package local
 
 import (
-	"fmt"
 	"log"
-	"os"
-	"text/tabwriter"
 )
 
 func Services(cachePath string) {
@@ -19,15 +16,11 @@ func Services(cachePath string) {
 	broker := startBroker(pakDir)
 	defer broker.Stop()
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.StripEscape)
-	_, _ = fmt.Fprintln(w)
-	_, _ = fmt.Fprintln(w, "Name\tService offering\tPlan")
-	_, _ = fmt.Fprintln(w, "----\t----------------\t----")
+	tp := newTablePrinter("Name", "Service offering", "Plan", "GUID")
 	for _, id := range ids {
 		instance := lookupServiceInstanceByGUID(id)
 		serviceName, planName := lookupServiceNamesByID(broker.Client, instance.ServiceOfferingGUID, instance.ServicePlanGUID)
-		_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", idToName(id), serviceName, planName)
+		tp.row(idToName(id), serviceName, planName, id)
 	}
-	_, _ = fmt.Fprintln(w)
-	_ = w.Flush()
+	tp.print()
 }

--- a/internal/local/table_printer.go
+++ b/internal/local/table_printer.go
@@ -1,0 +1,40 @@
+package local
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+)
+
+type tablePrinter struct {
+	w *tabwriter.Writer
+}
+
+func newTablePrinter(headings ...string) *tablePrinter {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', tabwriter.StripEscape)
+	_, _ = fmt.Fprintln(w)
+	_, _ = fmt.Fprintln(w, strings.Join(headings, "\t"))
+	_, _ = fmt.Fprintln(w, strings.Join(mapSlice(headings, toDivider), "\t"))
+	return &tablePrinter{w: w}
+}
+
+func (t *tablePrinter) row(data ...string) {
+	_, _ = fmt.Fprintf(t.w, "%s\n", strings.Join(data, "\t"))
+}
+
+func (t *tablePrinter) print() {
+	_, _ = fmt.Fprintln(t.w)
+	_ = t.w.Flush()
+}
+
+func toDivider(input string) string {
+	return strings.Repeat("-", len(input))
+}
+
+func mapSlice[A any](input []A, cb func(A) A) (result []A) {
+	for _, e := range input {
+		result = append(result, cb(e))
+	}
+	return
+}


### PR DESCRIPTION
The tabwriter is complex to use and the mechanics distract from the flow of the code. So a new tablePrinter object has been added to abstract the complexity away and reduce duplication.

