### PR TITLE
DO NOT MERGE feat: ability to stop merge of bind outputs with provision outputs

### DIFF
--- a/brokerapi/broker/bind.go
+++ b/brokerapi/broker/bind.go
@@ -151,10 +151,11 @@ func validateBindParameters(params map[string]any, validUserInputFields []broker
 // BuildInstanceCredentials combines the bind credentials with the connection
 // information in the instance details to get a full set of connection details.
 func buildInstanceCredentials(credentials map[string]any, outputs storage.JSONObject) (*domain.Binding, error) {
-	vc, err := varcontext.Builder().
-		MergeMap(outputs).
-		MergeMap(credentials).
-		Build()
+	if featureflags.Enabled(featureflags.DisableBindOutputMerging) {
+		return &domain.Binding{Credentials: credentials}, nil
+	}
+
+	vc, err := varcontext.Builder().MergeMap(outputs).MergeMap(credentials).Build()
 	if err != nil {
 		return nil, err
 	}

--- a/docs/brokerpak-dissection.md
+++ b/docs/brokerpak-dissection.md
@@ -616,8 +616,17 @@ Outputs from terraform will be collected into binding credentials.
 | type | field type |
 | details | Human readable description of output field |
 
-> output fields *must* be declared as *output* variables in terraform. Failure to do so will result in failures creating brokerpak
+Output fields *must* be declared as *output* variables in terraform. Failure to do so will result in failures creating brokerpak
 
-> binding credentials will contain all output variables from both the *provision* and *bind* portions of the service yaml.
+Output fields from the *provision* are can be accessed in the binding via `instance.details` in the computed inputs.
 
-> there is a special output parameter called *status* that may be declared in terraform, it does not need to be declared in the service manifest yaml. The *status* output value will be returned as the status message for the OSBAPI provision call and will be displayed to the user as the *message* portion of a `cf service <service name>` command. It is recommended that resource ID's and other information that may help a user identify the managed resource.
+By default, binding credentials will contain all output variables from both the *provision* and *bind* portions of the service yaml,
+with outputs from the *bind* having precedence.
+But if the `CSB_DISABLE_BIND_OUTPUT_MERGING` feature flag is enabled, then binding credentials will only
+contain outputs from the *bind*. This is considered to be preferable because the *provision* outputs will often
+contain administrator credentials, and there is a risk of them accidentally leaking into the binding credentials if
+brokerpak authors do not overwrite them by creating *bind* outputs with the same name. If an output from the
+*provision* should appear in the binding credentials, then it should be make an input and output of the binding so
+that it gets copied.
+
+There is a special output parameter called *status* that may be declared in terraform, it does not need to be declared in the service manifest yaml. The *status* output value will be returned as the status message for the OSBAPI provision call and will be displayed to the user as the *message* portion of a `cf service <service name>` command. It is recommended that resource ID's and other information that may help a user identify the managed resource.

--- a/pkg/featureflags/feature_flags.go
+++ b/pkg/featureflags/feature_flags.go
@@ -9,13 +9,21 @@ const (
 	TfUpgradeEnabled                 FeatureFlagName = "brokerpak.terraform.upgrades.enabled"
 	DynamicHCLEnabled                FeatureFlagName = "brokerpak.updates.enabled"
 	DisableRequestPropertyValidation FeatureFlagName = "request.property.validation.disabled"
+
+	// DisableBindOutputMerging is a feature flag that enables the legacy behavior of merging the output from
+	// the provision with the outputs from the binding. Instead, outputs required in the binding should be explicitly
+	// copied rather than defaulting to being copied. This prevents potential security issues where a provision operation
+	// may create and admin user, and the credentials for that admin user should not be leaked into the binding credentials.
+	// This feature flag will be removed in the future, so it's better to update a brokerpak than to try and rely on this flag.
+	DisableBindOutputMerging FeatureFlagName = "bind.output.merging.disabled"
 )
 
 func init() {
 	for ffName, varName := range map[FeatureFlagName]string{
-		TfUpgradeEnabled:                 "TERRAFORM_UPGRADES_ENABLED",
-		DynamicHCLEnabled:                "BROKERPAK_UPDATES_ENABLED",
+		TfUpgradeEnabled:                 "TERRAFORM_UPGRADES_ENABLED", // deprecated pattern - future variables should start CSB_
+		DynamicHCLEnabled:                "BROKERPAK_UPDATES_ENABLED",  // deprecated pattern - future variables should start CSB_
 		DisableRequestPropertyValidation: "CSB_DISABLE_REQUEST_PROPERTY_VALIDATION",
+		DisableBindOutputMerging:         "CSB_DISABLE_BIND_OUTPUT_MERGING",
 	} {
 		viper.BindEnv(string(ffName), varName)
 		viper.SetDefault(string(ffName), false)


### PR DESCRIPTION
**DON'T MERGE YET, WE NEED A TEAM DISCUSSION ABOUT THIS**
    
There is a feature flag `CSB_DISABLE_BIND_OUTPUT_MERGING` that will
stop the outputs from the provision operation from appearing in binding
credentials.
    
Up until now, binding credentials have been a merge of Terraform outputs
from the bind operation and Terraform outputs from the provision
operation.
    
This is behaviour is undesirable because:
- many brokerpaks explicitly copy data from the instance to the credentials, and in general it's better to have one way of doing things
- explicitly copying data is easier to reason about, many folks found this behaviour unexpected (although it was documented)
- it's easy to make a security mistake. At the moment many brokerpaks create an admin user during a provision operation, and mask the values in the bind (e.g. by overwriting username/password with a non-admin user). An innocent looking rename (e.g. password -> admin_password) could have the effect of leaking admin credentials in a binding.
    
In the future, this may be made the default behaviour.

[#184269641](https://www.pivotaltracker.com/story/show/184269641)
