### PR TITLE
chore: remove direct usage of gorilla/mux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	code.cloudfoundry.org/lager v2.0.0+incompatible
 	github.com/go-sql-driver/mysql v1.7.0
 	github.com/google/gops v0.3.26
-	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-getter v1.6.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.6.0
@@ -62,6 +61,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.1 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect

--- a/pkg/server/docs.go
+++ b/pkg/server/docs.go
@@ -19,7 +19,6 @@ import (
 	"html/template"
 	"net/http"
 
-	"github.com/gorilla/mux"
 	"github.com/russross/blackfriday/v2"
 
 	"github.com/cloudfoundry/cloud-service-broker/pkg/broker"
@@ -61,14 +60,12 @@ var pageTemplate = template.Must(template.New("docs-page").Parse(`
 </html>
 `))
 
-// AddDocsHandler creates a handler func that generates HTML documentation for
+// DocsHandler creates a handler func that generates HTML documentation for
 // the given registry and adds it to the /docs and / routes.
-func AddDocsHandler(router *mux.Router, registry broker.BrokerRegistry) {
+func DocsHandler(registry broker.BrokerRegistry) http.HandlerFunc {
 	docsPageMd := generator.CatalogDocumentation(registry)
 	handler := renderAsPage("Service Broker Documents", docsPageMd)
-
-	router.Handle("/docs", handler)
-	router.Handle("/", handler)
+	return handler
 }
 
 func renderAsPage(title, markdownContents string) http.HandlerFunc {

--- a/pkg/server/health.go
+++ b/pkg/server/health.go
@@ -16,15 +16,15 @@ package server
 
 import (
 	"database/sql"
+	"net/http"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/heptiolabs/healthcheck"
 )
 
 // AddHealthHandler creates a new handler for health and liveness checks and
 // adds it to the /live and /ready endpoints.
-func AddHealthHandler(router *mux.Router, db *sql.DB) healthcheck.Handler {
+func AddHealthHandler(router *http.ServeMux, db *sql.DB) healthcheck.Handler {
 	health := healthcheck.NewHandler()
 
 	if db != nil {

--- a/pkg/server/health_test.go
+++ b/pkg/server/health_test.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/gorilla/mux"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 )
@@ -83,7 +82,7 @@ func TestNewHealthHandler(t *testing.T) {
 
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
-			router := mux.NewRouter()
+			router := http.NewServeMux()
 			sqldb, err := db.DB()
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
The gorilla/mux project has been archived which means that we can't rely on receiving security fixes in the future. The brokerapi package is tightly integrated with gorilla/mux, but the cloud-service-broker code only uses it as a convenience. This commit removes direct usage of gorilla/mux, but the project still uses it indirectly via brokerapi.

[#184006000](https://www.pivotaltracker.com/story/show/184006000)