### PR TITLE
fix: broker should not start when no services are definied

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -107,10 +107,14 @@ func serve() {
 	}
 
 	services, err := serviceBroker.Services(context.Background())
-	if err != nil {
+	switch {
+	case len(services) == 0:
+		logger.Fatal("refusing to start", fmt.Errorf("no services are defined"))
+	case err != nil:
 		logger.Error("creating service catalog", err)
+	default:
+		logger.Info("service catalog", lager.Data{"catalog": displaycatalog.DisplayCatalog(services)})
 	}
-	logger.Info("service catalog", lager.Data{"catalog": displaycatalog.DisplayCatalog(services)})
 
 	brokerAPI := brokerapi.New(serviceBroker, logger, credentials)
 

--- a/integrationtest/no_services_test.go
+++ b/integrationtest/no_services_test.go
@@ -1,0 +1,16 @@
+package integrationtest_test
+
+import (
+	"github.com/cloudfoundry/cloud-service-broker/internal/testdrive"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("No services", func() {
+	It("fails to start", func() {
+		brokerpak := GinkgoT().TempDir()
+		broker, err := testdrive.StartBroker(csb, brokerpak, database, testdrive.WithOutputs(GinkgoWriter, GinkgoWriter))
+		Expect(broker.Stop()).To(Succeed()) // clean up just in case
+		Expect(err).To(MatchError(ContainSubstring("no services are defined")))
+	})
+})


### PR DESCRIPTION
From time to time, someone misconfigures the broker so that no services are defined. When this happens, the broker starts successfully but when registering to CloudFoundry the "cf create-service-broker" command fails. Often folks spend a lot of time investigating CloudFoundry, when an earlier failure would have directed them to the source of the problem. This commit introduces the earlier failure by refusing to start when no services are defined.
