### PR TITLE
fix: invalid cache state causing invalid brokerpaks

### DIFF
--- a/internal/brokerpak/packer/cache.go
+++ b/internal/brokerpak/packer/cache.go
@@ -22,7 +22,7 @@ func cachedFetchFile(getter func(source string, destination string) error, sourc
 	case exists(source):
 		log.Println("\t", source, "->", destination, "(local file)")
 		return copyLocalFile(source, destination)
-	case exists(cacheKey):
+	case cacheDirHasContents(cacheKey):
 		log.Println("\t", source, "->", destination, "(from cache)")
 		return cp.Copy(cacheKey, destination)
 	default:
@@ -38,6 +38,20 @@ func buildCacheKey(cachePath string, source string) string {
 func exists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// cacheDirHasContents checks that the cache directory still has the data, as files in /tmp are
+// sometimes cleaned up by the operating system
+func cacheDirHasContents(path string) bool {
+	if !exists(path) {
+		return false
+	}
+
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	return len(entries) > 0
 }
 
 func copyLocalFile(source, destination string) error {


### PR DESCRIPTION
When using a cache to build brokerpaks, a source path is converted into an MD5 sum and this is used to name a directory in the cache, which is populated by the contents. It was observed that cache directories were sometimes empty - presumably because the operating system was cleaning up files in /tmp. But because the cache directory still existed, it was still considered valid, and a brokerpak would be successfully built, but with missing content. This commit introduces an additional check that the cache directory should not be empty, which should resolve this kind of error.
