### PR TITLE
feat: `pak init` to include usable GUIDs in the template

### DIFF
--- a/internal/brokerpak/reader/reader_test.go
+++ b/internal/brokerpak/reader/reader_test.go
@@ -222,7 +222,7 @@ func fakeBrokerpak(opts ...option) string {
 	Expect(stream.Copy(stream.FromYaml(m), stream.ToFile(dir, "manifest.yml"))).NotTo(HaveOccurred())
 
 	for _, sdPath := range m.ServiceDefinitions {
-		Expect(stream.Copy(stream.FromYaml(tf.NewExampleTfServiceDefinition()), stream.ToFile(dir, sdPath))).NotTo(HaveOccurred())
+		Expect(stream.Copy(stream.FromYaml(tf.NewExampleTfServiceDefinition("00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000")), stream.ToFile(dir, sdPath))).NotTo(HaveOccurred())
 	}
 
 	packName := path.Join(GinkgoT().TempDir(), "fake.brokerpak")

--- a/pkg/brokerpak/cmd.go
+++ b/pkg/brokerpak/cmd.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"text/tabwriter"
 
+	"github.com/pborman/uuid"
+
 	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/manifest"
 	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/packer"
 	"github.com/cloudfoundry/cloud-service-broker/internal/brokerpak/platform"
@@ -46,7 +48,8 @@ func Init(directory string) error {
 		return err
 	}
 
-	if err := stream.Copy(stream.FromYaml(tf.NewExampleTfServiceDefinition()), stream.ToFile(directory, "example-service-definition.yml")); err != nil {
+	if err := stream.Copy(stream.FromYaml(tf.NewExampleTfServiceDefinition(uuid.New(), uuid.New())),
+		stream.ToFile(directory, "example-service-definition.yml")); err != nil {
 		return err
 	}
 
@@ -135,14 +138,15 @@ func finfo(pack string, out io.Writer) error {
 		fmt.Fprintln(out, "Dependencies")
 		w := cmdTabWriter(out)
 		fmt.Fprintln(w, "NAME\tVERSION\tSOURCE")
+		const tableRowTemplate = "%s\t%s\t%s\n"
 		for _, resource := range mf.TerraformVersions {
-			fmt.Fprintf(w, "%s\t%s\t%s\n", "terraform", resource.Version.String(), resource.Source)
+			fmt.Fprintf(w, tableRowTemplate, "terraform", resource.Version.String(), resource.Source)
 		}
 		for _, resource := range mf.TerraformProviders {
-			fmt.Fprintf(w, "%s\t%s\t%s\n", resource.Name, resource.Version.String(), resource.Source)
+			fmt.Fprintf(w, tableRowTemplate, resource.Name, resource.Version.String(), resource.Source)
 		}
 		for _, resource := range mf.Binaries {
-			fmt.Fprintf(w, "%s\t%s\t%s\n", resource.Name, resource.Version, resource.Source)
+			fmt.Fprintf(w, tableRowTemplate, resource.Name, resource.Version, resource.Source)
 		}
 		w.Flush()
 		fmt.Fprintln(out)

--- a/pkg/brokerpak/cmd_test.go
+++ b/pkg/brokerpak/cmd_test.go
@@ -90,7 +90,7 @@ func fakeBrokerpak() (string, error) {
 	}
 
 	for _, path := range exampleManifest.ServiceDefinitions {
-		if err := stream.Copy(stream.FromYaml(tf.NewExampleTfServiceDefinition()), stream.ToFile(dir, path)); err != nil {
+		if err := stream.Copy(stream.FromYaml(tf.NewExampleTfServiceDefinition("00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000")), stream.ToFile(dir, path)); err != nil {
 			return "", err
 		}
 	}

--- a/pkg/brokerpak/registrar_test.go
+++ b/pkg/brokerpak/registrar_test.go
@@ -393,7 +393,7 @@ func TestRegistrar_walk(t *testing.T) {
 }
 
 func fakeDefn(name, id string) tf.TfServiceDefinitionV1 {
-	ex := tf.NewExampleTfServiceDefinition()
+	ex := tf.NewExampleTfServiceDefinition("00000000-0000-0000-0000-000000000000", "00000000-0000-0000-0000-000000000000")
 	ex.ID = id
 	ex.Name = "service-" + name
 

--- a/pkg/providers/tf/definition.go
+++ b/pkg/providers/tf/definition.go
@@ -20,18 +20,15 @@ import (
 	"path"
 	"strings"
 
-	"github.com/cloudfoundry/cloud-service-broker/internal/serviceimage"
-
-	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf/executor"
-
-	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf/invoker"
-	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf/workspace"
-
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/pivotal-cf/brokerapi/v10/domain"
 	"github.com/spf13/viper"
 
+	"github.com/cloudfoundry/cloud-service-broker/internal/serviceimage"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/broker"
+	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf/executor"
+	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf/invoker"
+	"github.com/cloudfoundry/cloud-service-broker/pkg/providers/tf/workspace"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/validation"
 	"github.com/cloudfoundry/cloud-service-broker/pkg/varcontext"
 	"github.com/cloudfoundry/cloud-service-broker/utils"
@@ -40,11 +37,11 @@ import (
 // NewExampleTfServiceDefinition creates a new service definition with sample
 // values for the service broker suitable to give a user a template to manually
 // edit.
-func NewExampleTfServiceDefinition() TfServiceDefinitionV1 {
+func NewExampleTfServiceDefinition(serviceID string, planID string) TfServiceDefinitionV1 {
 	return TfServiceDefinitionV1{
 		Version:          1,
 		Name:             "example-service",
-		ID:               "00000000-0000-0000-0000-000000000000",
+		ID:               serviceID,
 		Description:      "a longer service description",
 		DisplayName:      "Example Service",
 		ImageURL:         "https://example.com/icon.jpg",
@@ -53,7 +50,7 @@ func NewExampleTfServiceDefinition() TfServiceDefinitionV1 {
 		Tags:             []string{"gcp", "example", "service"},
 		Plans: []TfServiceDefinitionV1Plan{
 			{
-				ID:          "00000000-0000-0000-0000-000000000001",
+				ID:          planID,
 				Name:        "example-email-plan",
 				DisplayName: "example.com email builder",
 				Description: "Builds emails for example.com.",
@@ -135,7 +132,7 @@ func NewExampleTfServiceDefinition() TfServiceDefinitionV1 {
 			{
 				Name:            "Example",
 				Description:     "Examples are used for documenting your service AND as integration tests.",
-				PlanID:          "00000000-0000-0000-0000-000000000001",
+				PlanID:          planID,
 				ProvisionParams: map[string]any{"username": "my-account"},
 				BindParams:      map[string]any{},
 			},


### PR DESCRIPTION
Previously, the newly created brokerpak had `00000000-0000-0000-0000-000000000000` as the service GUID, and
`00000000-0000-0000-0000-000000000001` as the plan GUID. This would require the author to re-generate the above values. The probability of GUIDs clashing in this case is negligible.

### Checklist:

* [~] Have you added or updated tests to validate the changed functionality?
* [~] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

