### PR TITLE
chore: pin Dockerfile Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ ADD . /app
 ARG CSB_VERSION=0.0.0
 RUN CGO_ENABLED=1 GOOS=linux go build -o ./build/cloud-service-broker -ldflags "-X github.com/cloudfoundry/cloud-service-broker/utils.Version=$CSB_VERSION"
 
-FROM alpine:latest
+# Currently can't go to 3.19 due to issue: https://github.com/mattn/go-sqlite3/issues/1164#issuecomment-1848677118
+FROM alpine:3.18
 
 COPY --from=build /app/build/cloud-service-broker /bin/cloud-service-broker
 


### PR DESCRIPTION
Pins the version of Alpine in the Dockerfile to avoid an issue where the latest Alpine does not work with sqllite.

[#186660285](https://www.pivotaltracker.com/story/show/186660285)
