### PR TITLE
chore: make codeql action use golang specified in go.mod

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,12 @@ jobs:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
+      # Install golang used by this project (https://github.com/github/codeql-action/issues/1842)
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: "go.mod"
+
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,9 +39,9 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3.24.0
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.24.0
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cloud-service-broker
 
-go 1.22.0
+go 1.22
 
 require (
 	code.cloudfoundry.org/credhub-cli v0.0.0-20220620130410-645eee56ecdb

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cloud-service-broker
 
-go 1.22
+go 1.22.0
 
 require (
 	code.cloudfoundry.org/credhub-cli v0.0.0-20220620130410-645eee56ecdb


### PR DESCRIPTION
Related PRs:
- https://github.com/argentumcode/systemd-failure-pagerduty/pull/8/files
- https://github.com/cloudfoundry/cloud-service-broker/pull/947
- https://github.com/cloudfoundry/cloud-service-broker/pull/948

### Checklist:

* [ ] Have you added or updated tests to validate the changed functionality?
* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

