### PR TITLE
chore: specify go 1.22.0 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cloudfoundry/cloud-service-broker
 
-go 1.22
+go 1.22.0
 
 require (
 	code.cloudfoundry.org/credhub-cli v0.0.0-20220620130410-645eee56ecdb


### PR DESCRIPTION
Related PRs:
- https://github.com/pivotal/cloud-service-broker-ci/pull/795
- https://github.com/cloudfoundry/cloud-service-broker/pull/947

### Checklist:

* [ ] Have you added or updated tests to validate the changed functionality?
* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

