### PR TITLE
chore: stop checking go version in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 SHELL = /bin/bash
-GO-VERSION = 1.22.0
-GO-VER = go$(GO-VERSION)
 
 PAK_CACHE=$(PWD)/.pak-cache
 
@@ -29,15 +27,6 @@ LDFLAGS="-X github.com/cloudfoundry/cloud-service-broker/utils.Version=$(VERSION
 
 PKG="github.com/cloudfoundry/cloud-service-broker"
 
-.PHONY: deps-go-binary
-deps-go-binary:
-ifeq ($(SKIP_GO_VERSION_CHECK),)
-	@@if [ "$$(go version | awk '{print $$3}')" != "${GO-VER}" ]; then \
-		echo "Go version does not match: expected: ${GO-VER}, got $$(go version | awk '{print $$3}')"; \
-		exit 1; \
-	fi
-endif
-
 ###### Help ###################################################################
 
 .DEFAULT_GOAL = help
@@ -53,12 +42,12 @@ help: ## list Makefile targets
 test: download lint test-units test-integration ## run lint and unit tests
 
 .PHONY: test-units
-test-units: deps-go-binary ## run unit tests
+test-units: ## run unit tests
 	go test $(PKG)/brokerapi/... $(PKG)/cmd/... $(PKG)/dbservice/... $(PKG)/internal/... $(PKG)/pkg/... $(PKG)/utils/... -tags=service_broker
 
 # Integration tests are relatively resource-hungry, so we tune down the number of processes that run in parallel
 .PHONY: test-integration
-test-integration: deps-go-binary .pak-cache ## run integration tests
+test-integration: .pak-cache ## run integration tests
 	PAK_BUILD_CACHE_PATH=$(PAK_CACHE) go run github.com/onsi/ginkgo/v2/ginkgo --procs 4 integrationtest/...
 
 .pak-cache:
@@ -80,10 +69,10 @@ test-units-coverage: ## test-units coverage score
 	GOARCH=amd64 GOOS=darwin go build -o ./build/cloud-service-broker.darwin -ldflags ${LDFLAGS}
 
 .PHONY: build
-build: deps-go-binary ./build/cloud-service-broker.linux ./build/cloud-service-broker.darwin ## build binary
+build: ./build/cloud-service-broker.linux ./build/cloud-service-broker.darwin ## build binary
 
 .PHONY: install
-install: deps-go-binary ## install as /usr/local/bin/csb
+install: ## install as /usr/local/bin/csb
 	go build -o csb -ldflags ${LDFLAGS}
 	mv csb /usr/local/bin/csb
 
@@ -99,7 +88,7 @@ download: ## download go module dependencies
 ###### Clean ##################################################################
 
 .PHONY: clean
-clean: deps-go-binary ## clean up from previous builds
+clean: ## clean up from previous builds
 	-go clean --modcache
 	-rm -rf ./build
 	-rm -rf /tmp/csb-non-fake.txt

--- a/docs/user-guides/developer-experience.md
+++ b/docs/user-guides/developer-experience.md
@@ -31,13 +31,22 @@ The next command will build the CSB, and install it in your local machine with t
   go build -o csb -ldflags "-X github.com/cloudfoundry/cloud-service-broker/utils.Version=v0.14.0-1b000966"
   mv csb /usr/local/bin/csb
   ```
-If you do not have the latest version of Go, you will get an error similar to this:
+If you do not have a recent version of Go, you will get an error similar to this:
 
   ```shell
-  {▪} ~/workspace/csb/cloud-service-broker on main ✓ make install
-  Go version does not match: expected: go1.19.5, got go1.18.2
-  make: *** [Makefile:45: deps-go-binary] Error 1
+  go: errors parsing go.mod:
+  /go/cloud-service-broker/go.mod:3: invalid go version '1.22.0': must match format 1.23
   ```
+
+You can also get an error despite having a recent version of Go (>= 1.21), if `GOTOOLCHAIN=local` is set.
+
+  ```shell
+  go: go.mod requires go >= 1.22.0 (running go 1.21.7; GOTOOLCHAIN=local)
+  ```
+In such cases you may want to:
+* Set `GOTOOLCHAIN=auto` either for just one command or the entire shell session.
+* Manually download and install the latest version of Go.
+
 After installing the CSB binary, you will be ready to advance to the next step.
 
 ##### Check the installation


### PR DESCRIPTION
[#187027977](https://www.pivotaltracker.com/story/show/187027977)

Before Go 1.21:
- The go directive was advisory only; now it is a mandatory requirement
- The go directive didn't allow specifying patch versions

So, by specifying the patch version in go.mod:
- Noone can unknowingly test, run or build this project using an older version of go
- The required Go toolchain can be downloaded automatically

Therefore, checking the current go version in Makefile is no longer needed.

### Checklist:

* [ ] Have you added or updated tests to validate the changed functionality?
* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

