### PR TITLE
test: golden path integration test

### DIFF
--- a/integrationtest/fixtures/golden-path/fake-uuid-bind.tf
+++ b/integrationtest/fixtures/golden-path/fake-uuid-bind.tf
@@ -1,0 +1,3 @@
+resource "random_uuid" "random" {}
+
+output bind_output { value = random_uuid.random.result }

--- a/integrationtest/fixtures/golden-path/fake-uuid-provision.tf
+++ b/integrationtest/fixtures/golden-path/fake-uuid-provision.tf
@@ -1,0 +1,3 @@
+resource "random_uuid" "random" {}
+
+output provision_output { value = random_uuid.random.result }

--- a/integrationtest/fixtures/golden-path/fake-uuid-service.yml
+++ b/integrationtest/fixtures/golden-path/fake-uuid-service.yml
@@ -1,0 +1,27 @@
+version: 1
+name: fake-uuid-service
+id: f18d50e2-cbf0-11ee-a64b-f7a425623295
+description: description
+display_name: Fake
+image_url: https://example.com/icon.jpg
+documentation_url: https://example.com
+support_url: https://example.com/support.html
+plans:
+- name: standard
+  id: fd01df6a-cbf0-11ee-ac5b-fba53664a953
+  description: Standard plan
+  display_name: Standard
+provision:
+  template_refs:
+    main: fake-uuid-provision.tf
+  outputs:
+    - field_name: provision_output
+      type: string
+      details: provision output
+bind:
+  template_refs:
+    main: fake-uuid-bind.tf
+  outputs:
+    - field_name: bind_output
+      type: string
+      details: bind output

--- a/integrationtest/fixtures/golden-path/manifest.yml
+++ b/integrationtest/fixtures/golden-path/manifest.yml
@@ -1,0 +1,18 @@
+packversion: 1
+name: fake-brokerpak
+version: 0.1.0
+metadata:
+  author: noone@nowhere.com
+platforms:
+- os: linux
+  arch: amd64
+- os: darwin
+  arch: amd64
+terraform_binaries:
+- name: terraform
+  version: 1.5.7
+  source: https://github.com/hashicorp/terraform/archive/v1.5.7.zip
+- name: terraform-provider-random
+  version: 3.1.0
+service_definitions:
+- fake-uuid-service.yml

--- a/integrationtest/golden_path_test.go
+++ b/integrationtest/golden_path_test.go
@@ -1,0 +1,51 @@
+package integrationtest_test
+
+import (
+	"encoding/json"
+
+	"github.com/cloudfoundry/cloud-service-broker/integrationtest/packer"
+	"github.com/cloudfoundry/cloud-service-broker/internal/testdrive"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Golden Path", func() {
+	const (
+		serviceOfferingGUID = "f18d50e2-cbf0-11ee-a64b-f7a425623295"
+		servicePlanGUID     = "fd01df6a-cbf0-11ee-ac5b-fba53664a953"
+	)
+
+	var (
+		brokerpak string
+		broker    *testdrive.Broker
+	)
+
+	BeforeEach(func() {
+		brokerpak = must(packer.BuildBrokerpak(csb, fixtures("golden-path")))
+		broker = must(testdrive.StartBroker(csb, brokerpak, database))
+
+		DeferCleanup(func() {
+			Expect(broker.Stop()).To(Succeed())
+			cleanup(brokerpak)
+		})
+	})
+
+	It("can create and delete a service instance and a binding", func() {
+		instance := must(broker.Provision(serviceOfferingGUID, servicePlanGUID))
+
+		binding := must(broker.CreateBinding(instance))
+		var receiver struct {
+			Credentials struct {
+				BindOutput      string `json:"bind_output"`
+				ProvisionOutput string `json:"provision_output"`
+			} `json:"credentials"`
+		}
+		Expect(json.Unmarshal([]byte(binding.Body), &receiver)).To(Succeed())
+		Expect(receiver.Credentials.ProvisionOutput).To(MatchRegexp(`^[-0-9a-f]{36}$`))
+		Expect(receiver.Credentials.BindOutput).To(MatchRegexp(`^[-0-9a-f]{36}$`))
+
+		Expect(broker.DeleteBinding(instance, binding.GUID)).To(Succeed())
+		Expect(broker.Deprovision(instance)).To(Succeed())
+	})
+})


### PR DESCRIPTION
Existing integration tests cover complex scenarios. There's value in having a simple one that tests the golden path of a service lifecycle, mainly for debugging or detecting catastrophic bugs.

[#185835561](https://www.pivotaltracker.com/story/show/185835561)
