### PR TITLE
fix: successfully delete instances and bindings with invalid state

### DIFF
--- a/integrationtest/binding_cleanup_test.go
+++ b/integrationtest/binding_cleanup_test.go
@@ -48,8 +48,7 @@ var _ = Describe("Binding Cleanup", func() {
 		Expect(broker.DeleteBinding(instance, binding.GUID)).To(MatchError(ContainSubstring("unexpected status code 410")))
 	})
 
-	// This test captures an incorrect behavior that we want to fix
-	It("fails to clean up after a corrupted binding", func() {
+	It("successfully deletes a corrupted binding", func() {
 		By("provisioning successfully")
 		instance := must(broker.Provision(goodServiceOfferingGUID, goodServicePlanGUID))
 
@@ -65,7 +64,10 @@ var _ = Describe("Binding Cleanup", func() {
 				Error,
 		).To(Succeed())
 
-		By("failing to clean up the binding")
-		Expect(broker.DeleteBinding(instance, binding.GUID)).To(MatchError(ContainSubstring("failed to unbind: invalid workspace state unexpected end of JSON input")))
+		By("deleting the binding")
+		Expect(broker.DeleteBinding(instance, binding.GUID)).To(Succeed())
+
+		By("logging that the version could not be read")
+		Expect(broker.Stdout.String()).To(ContainSubstring("unbind-cannot-read-version"))
 	})
 })

--- a/integrationtest/provision_cleanup_test.go
+++ b/integrationtest/provision_cleanup_test.go
@@ -34,18 +34,19 @@ var _ = Describe("Provision Cleanup", func() {
 		})
 	})
 
-	// This test captures an incorrect behavior that we want to fix
-	It("fails to clean up after a provision failed with empty state", func() {
+	It("successfully deletes after failed provision with empty state", func() {
 		By("failing to provision")
 		instance, err := broker.Provision(serviceOfferingGUID, servicePlanGUID)
 		Expect(err).To(MatchError("provision failed with state: failed"))
 
-		By("failing to clean up")
-		Expect(broker.Deprovision(instance)).To(MatchError(ContainSubstring("failed to delete: workspace state not generated")))
+		By("deleting the service instance")
+		Expect(broker.Deprovision(instance)).To(Succeed())
+
+		By("logging that the version could not be read")
+		Expect(broker.Stdout.String()).To(ContainSubstring("deprovision-cannot-read-version"))
 	})
 
-	// This test captures an incorrect behavior that we want to fix
-	It("fails to clean up after a provision failed with corrupted state", func() {
+	It("successfully deletes after failed provision with corrupted state", func() {
 		By("failing to provision")
 		instance, err := broker.Provision(serviceOfferingGUID, servicePlanGUID)
 		Expect(err).To(MatchError("provision failed with state: failed"))
@@ -59,7 +60,10 @@ var _ = Describe("Provision Cleanup", func() {
 				Error,
 		).To(Succeed())
 
-		By("failing to clean up")
-		Expect(broker.Deprovision(instance)).To(MatchError(ContainSubstring("failed to delete: invalid workspace state unexpected end of JSON input")))
+		By("deleting the service instance")
+		Expect(broker.Deprovision(instance)).To(Succeed())
+
+		By("logging that the version could not be read")
+		Expect(broker.Stdout.String()).To(ContainSubstring("deprovision-cannot-read-version"))
 	})
 })

--- a/internal/testdrive/broker_deprovision.go
+++ b/internal/testdrive/broker_deprovision.go
@@ -13,7 +13,10 @@ func (b *Broker) Deprovision(s ServiceInstance) error {
 	switch {
 	case deprovisionResponse.Error != nil:
 		return deprovisionResponse.Error
-	case deprovisionResponse.StatusCode != http.StatusAccepted:
+	case deprovisionResponse.StatusCode == http.StatusOK: // ok - synchronous
+		return nil
+	case deprovisionResponse.StatusCode == http.StatusAccepted: // ok - asynchronous - poll last operation
+	default:
 		return &UnexpectedStatusError{StatusCode: deprovisionResponse.StatusCode, ResponseBody: deprovisionResponse.ResponseBody}
 	}
 

--- a/pkg/providers/tf/workspace/cannot_read_version_error.go
+++ b/pkg/providers/tf/workspace/cannot_read_version_error.go
@@ -1,0 +1,9 @@
+package workspace
+
+type CannotReadVersionError struct {
+	message string
+}
+
+func (s CannotReadVersionError) Error() string {
+	return s.message
+}

--- a/pkg/providers/tf/workspace/workspace.go
+++ b/pkg/providers/tf/workspace/workspace.go
@@ -114,16 +114,15 @@ type TerraformWorkspace struct {
 }
 
 func (workspace *TerraformWorkspace) StateTFVersion() (*version.Version, error) {
+	if !workspace.HasState() {
+		return nil, CannotReadVersionError{message: "workspace state not generated"}
+	}
+
 	var receiver struct {
 		Version string `json:"terraform_version"`
 	}
-
-	if workspace.State == nil {
-		return nil, fmt.Errorf("workspace state not generated")
-	}
-
 	if err := json.Unmarshal(workspace.State, &receiver); err != nil {
-		return nil, fmt.Errorf("invalid workspace state %w", err)
+		return nil, CannotReadVersionError{message: fmt.Sprintf("invalid workspace state %s", err)}
 	}
 
 	return version.NewVersion(receiver.Version)


### PR DESCRIPTION
NOTE: please merge PR #954 first

As part of the upgrade epic, we added checks to make sure that service
instances and bindings had been updated to the latest version. This
involves parsing the Terraform state and extracting the version. But
sometimes the Terraform state is not valid due to being empty, or being
invalid JSON. Typically this is after a failure to provision/bind,
and the service instance or binding is in a failed state. In these
situations, the lack of state data means CSB does not have enough data to
successfully clean up using Terraform. We have had feedback that this
can be problematic for users because they have to do a manual purge of
the service instance, and it would be easier if the delete operations
would just work. This is a tradeoff because a manual purge could have
the effect of triggering someone to look at the backing IaaS to look for
resource leakage. By making this just work, we might make resource
leakage worse.

[#185835561](https://www.pivotaltracker.com/story/show/185835561)
