### PR TITLE
fix: only run database startup when running server

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -84,7 +84,7 @@ func init() {
 func serve() {
 	logger := utils.NewLogger("cloud-service-broker")
 	logger.Info("starting", lager.Data{"version": utils.Version})
-	db := dbservice.New(logger)
+	db := dbservice.NewWithMigrations(logger)
 	encryptor := setupDBEncryption(db, logger)
 
 	// init broker

--- a/dbservice/dbservice.go
+++ b/dbservice/dbservice.go
@@ -26,8 +26,17 @@ import (
 
 var once sync.Once
 
-// New instantiates the db connection and runs migrations
+// New instantiates the db connection without running migrations
 func New(logger lager.Logger) *gorm.DB {
+	var db *gorm.DB
+	once.Do(func() {
+		db = SetupDB(logger)
+	})
+	return db
+}
+
+// NewWithMigrations instantiates the db connection and runs migrations
+func NewWithMigrations(logger lager.Logger) *gorm.DB {
 	var db *gorm.DB
 	once.Do(func() {
 		db = SetupDB(logger)

--- a/dbservice/dbservice_suite_test.go
+++ b/dbservice/dbservice_suite_test.go
@@ -1,4 +1,4 @@
-package dbservice_test
+package dbservice
 
 import (
 	"testing"

--- a/integrationtest/tf_dump_test.go
+++ b/integrationtest/tf_dump_test.go
@@ -1,0 +1,29 @@
+package integrationtest_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/gomega/gbytes"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("TF Dump", func() {
+	It("does not run database migration", func() {
+		cmd := exec.Command(csb, "tf", "dump", "tf:fake-id:")
+		cmd.Env = append(
+			os.Environ(),
+			"DB_TYPE=sqlite3",
+			fmt.Sprintf("DB_PATH=%s", database),
+		)
+		session, err := Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+		Eventually(session).WithTimeout(time.Minute).Should(Exit(2))
+		Expect(session.Err).To(Say("panic: no such table: password_metadata"))
+	})
+})


### PR DESCRIPTION
An error was discovered where database startup, including database migrations and failed operation recovery was being run for every command that accessed the database, including "tf dump". This had the effect of marking any in-progress operations as failed, even if they were still really in progress. This has been a problem since the introduction of in-progress operation recovery in v1.1.0 (commit c8452677ef3d141efd150c5adbd4392377e2439c).

[#187500102](https://www.pivotaltracker.com/story/show/187500102)

