### PR TITLE
fix: allow provider binaries without version in name

### DIFF
--- a/integrationtest/fixtures/opentofu-registry/fake-uuid-bind.tf
+++ b/integrationtest/fixtures/opentofu-registry/fake-uuid-bind.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "registry.opentofu.org/hashicorp/random"
+    }
+  }
+}
+
+resource "random_uuid" "random" {}
+
+output bind_output { value = random_uuid.random.result }

--- a/integrationtest/fixtures/opentofu-registry/fake-uuid-provision.tf
+++ b/integrationtest/fixtures/opentofu-registry/fake-uuid-provision.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "registry.opentofu.org/hashicorp/random"
+    }
+  }
+}
+
+resource "random_uuid" "random" {}
+
+output provision_output { value = random_uuid.random.result }

--- a/integrationtest/fixtures/opentofu-registry/fake-uuid-service.yml
+++ b/integrationtest/fixtures/opentofu-registry/fake-uuid-service.yml
@@ -1,0 +1,27 @@
+version: 1
+name: fake-uuid-service
+id: 131f8a0c-2db4-11ef-a409-cb227e5d535b
+description: description
+display_name: Fake
+image_url: https://example.com/icon.jpg
+documentation_url: https://example.com
+support_url: https://example.com/support.html
+plans:
+- name: standard
+  id: 1fd35418-2db4-11ef-8d23-678395cb3c33
+  description: Standard plan
+  display_name: Standard
+provision:
+  template_refs:
+    main: fake-uuid-provision.tf
+  outputs:
+    - field_name: provision_output
+      type: string
+      details: provision output
+bind:
+  template_refs:
+    main: fake-uuid-bind.tf
+  outputs:
+    - field_name: bind_output
+      type: string
+      details: bind output

--- a/integrationtest/fixtures/opentofu-registry/manifest.yml
+++ b/integrationtest/fixtures/opentofu-registry/manifest.yml
@@ -1,0 +1,20 @@
+packversion: 1
+name: fake-brokerpak
+version: 0.1.0
+metadata:
+  author: noone@nowhere.com
+platforms:
+- os: linux
+  arch: amd64
+- os: darwin
+  arch: amd64
+terraform_binaries:
+- name: tofu
+  version: 1.6.0
+  source: https://github.com/opentofu/opentofu/archive/refs/tags/v1.6.0.zip
+- name: terraform-provider-random
+  version: 3.6.2
+  provider: registry.opentofu.org/hashicorp/random
+  url_template: https://github.com/opentofu/${name}/releases/download/v${version}/${name}_${version}_${os}_${arch}.zip
+service_definitions:
+- fake-uuid-service.yml

--- a/integrationtest/opentofu_registry_test.go
+++ b/integrationtest/opentofu_registry_test.go
@@ -1,0 +1,51 @@
+package integrationtest_test
+
+import (
+	"encoding/json"
+
+	"github.com/cloudfoundry/cloud-service-broker/v2/integrationtest/packer"
+	"github.com/cloudfoundry/cloud-service-broker/v2/internal/testdrive"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OpenTofu registry", func() {
+	const (
+		serviceOfferingGUID = "131f8a0c-2db4-11ef-a409-cb227e5d535b"
+		servicePlanGUID     = "1fd35418-2db4-11ef-8d23-678395cb3c33"
+	)
+
+	var (
+		brokerpak string
+		broker    *testdrive.Broker
+	)
+
+	BeforeEach(func() {
+		brokerpak = must(packer.BuildBrokerpak(csb, fixtures("opentofu-registry")))
+		broker = must(testdrive.StartBroker(csb, brokerpak, database, testdrive.WithOutputs(GinkgoWriter, GinkgoWriter)))
+
+		DeferCleanup(func() {
+			Expect(broker.Stop()).To(Succeed())
+			cleanup(brokerpak)
+		})
+	})
+
+	It("can create and delete a service instance and a binding", func() {
+		instance := must(broker.Provision(serviceOfferingGUID, servicePlanGUID))
+
+		binding := must(broker.CreateBinding(instance))
+		var receiver struct {
+			Credentials struct {
+				BindOutput      string `json:"bind_output"`
+				ProvisionOutput string `json:"provision_output"`
+			} `json:"credentials"`
+		}
+		Expect(json.Unmarshal([]byte(binding.Body), &receiver)).To(Succeed())
+		Expect(receiver.Credentials.ProvisionOutput).To(MatchRegexp(`^[-0-9a-f]{36}$`))
+		Expect(receiver.Credentials.BindOutput).To(MatchRegexp(`^[-0-9a-f]{36}$`))
+
+		Expect(broker.DeleteBinding(instance, binding.GUID)).To(Succeed())
+		Expect(broker.Deprovision(instance)).To(Succeed())
+	})
+})


### PR DESCRIPTION
Historically providers have had the version as part of the file name. But some providers don't have this. This fix allows those providers to work, but with a tradeoff that you won't be able to have more than one version of that provider.