### PR TITLE
chore: remove unused code for sync deprovision

### DIFF
--- a/brokerapi/broker/deprovision.go
+++ b/brokerapi/broker/deprovision.go
@@ -99,15 +99,6 @@ func (broker *ServiceBroker) Deprovision(ctx context.Context, instanceID string,
 		return domain.DeprovisionServiceSpec{}, err
 	}
 
-	if operationID == nil {
-		// If this is a synchronous operation, then immediately remove the service instance data from the database
-		if err := broker.removeServiceInstanceData(ctx, instanceID, serviceProvider); err != nil {
-			return domain.DeprovisionServiceSpec{}, err
-		}
-
-		return domain.DeprovisionServiceSpec{}, nil
-	}
-
 	response := domain.DeprovisionServiceSpec{
 		IsAsync:       true,
 		OperationData: *operationID,


### PR DESCRIPTION
We had code to handle a sync deprovision, but the CSB cannot do a sync deprovision, so it's code that could never be run.