### PR TITLE
chore: report database error during LastOperation

### DIFF
--- a/brokerapi/broker/last_instance_operation.go
+++ b/brokerapi/broker/last_instance_operation.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	"code.cloudfoundry.org/lager/v3"
-	"github.com/pivotal-cf/brokerapi/v11/domain"
 	"github.com/pivotal-cf/brokerapi/v11/domain/apiresponses"
 
+	"code.cloudfoundry.org/lager/v3"
 	"github.com/cloudfoundry/cloud-service-broker/v2/dbservice/models"
 	"github.com/cloudfoundry/cloud-service-broker/v2/pkg/broker"
 	"github.com/cloudfoundry/cloud-service-broker/v2/utils/correlation"
+	"github.com/pivotal-cf/brokerapi/v11/domain"
 )
 
 // LastOperation fetches last operation state for a service instance.
@@ -24,9 +24,21 @@ func (broker *ServiceBroker) LastOperation(ctx context.Context, instanceID strin
 		"operation_data": details.OperationData,
 	})
 
+	// make sure that instance actually exists
+	// Technically according to OSBAPI we should return HTTP 410 Gone only if the operation is a Deprovision,
+	// and for Provision or Update we should return an HTTP 404 Not Found, but we do not do this, and the
+	// pivotal-cf/brokerapi/apiresponses package does not provide the required error to do this.
+	exists, err := broker.store.ExistsServiceInstanceDetails(instanceID)
+	switch {
+	case err != nil:
+		return domain.LastOperation{}, fmt.Errorf("database error checking for existing instance: %s", err)
+	case !exists:
+		return domain.LastOperation{}, apiresponses.ErrInstanceDoesNotExist
+	}
+
 	instance, err := broker.store.GetServiceInstanceDetails(instanceID)
 	if err != nil {
-		return domain.LastOperation{}, apiresponses.ErrInstanceDoesNotExist
+		return domain.LastOperation{}, fmt.Errorf("error getting service instance details: %w", err)
 	}
 
 	_, serviceProvider, err := broker.getDefinitionAndProvider(instance.ServiceGUID)


### PR DESCRIPTION
We now differentiate between an instance not existing, and having an error getting the record from the database. All the other endpoints did this, so this just gets LastOperation to follow the same pattern