### PR TITLE
chore: drop unused Location and URL database fields

### DIFF
--- a/dbservice/migrations.go
+++ b/dbservice/migrations.go
@@ -23,7 +23,7 @@ import (
 	"github.com/cloudfoundry/cloud-service-broker/v2/dbservice/models"
 )
 
-const numMigrations = 18
+const numMigrations = 17
 
 // RunMigrations runs schema migrations on the provided service broker database to get it up to date
 func RunMigrations(db *gorm.DB) error {
@@ -129,11 +129,16 @@ func RunMigrations(db *gorm.DB) error {
 	}
 
 	migrations[16] = func() error {
-		return db.Migrator().DropColumn(&models.ServiceInstanceDetailsV3{}, "operation_type")
-	}
-
-	migrations[17] = func() error {
-		return db.Migrator().DropColumn(&models.ServiceInstanceDetailsV3{}, "operation_id")
+		if err := db.Migrator().DropColumn(&models.ServiceInstanceDetailsV4{}, "operation_type"); err != nil {
+			return err
+		}
+		if err := db.Migrator().DropColumn(&models.ServiceInstanceDetailsV4{}, "operation_id"); err != nil {
+			return err
+		}
+		if err := db.Migrator().DropColumn(&models.ServiceInstanceDetailsV4{}, "location"); err != nil {
+			return err
+		}
+		return db.Migrator().DropColumn(&models.ServiceInstanceDetailsV4{}, "url")
 	}
 
 	var lastMigrationNumber = -1

--- a/dbservice/models/historical_db.go
+++ b/dbservice/models/historical_db.go
@@ -170,8 +170,6 @@ type ServiceInstanceDetailsV4 struct {
 	DeletedAt *time.Time
 
 	Name         string
-	Location     string
-	URL          string
 	OtherDetails []byte `gorm:"type:blob"`
 
 	ServiceID        string

--- a/internal/storage/service_instance_details.go
+++ b/internal/storage/service_instance_details.go
@@ -10,8 +10,6 @@ import (
 type ServiceInstanceDetails struct {
 	GUID             string
 	Name             string
-	Location         string
-	URL              string
 	Outputs          JSONObject
 	ServiceGUID      string
 	PlanGUID         string
@@ -31,8 +29,6 @@ func (s *Storage) StoreServiceInstanceDetails(d ServiceInstanceDetails) error {
 	}
 
 	m.Name = d.Name
-	m.Location = d.Location
-	m.URL = d.URL
 	m.OtherDetails = encoded
 	m.ServiceID = d.ServiceGUID
 	m.PlanID = d.PlanGUID
@@ -84,8 +80,6 @@ func (s *Storage) GetServiceInstanceDetails(guid string) (ServiceInstanceDetails
 	return ServiceInstanceDetails{
 		GUID:             guid,
 		Name:             receiver.Name,
-		Location:         receiver.Location,
-		URL:              receiver.URL,
 		Outputs:          decoded,
 		ServiceGUID:      receiver.ServiceID,
 		PlanGUID:         receiver.PlanID,

--- a/internal/storage/service_instance_details_test.go
+++ b/internal/storage/service_instance_details_test.go
@@ -15,8 +15,6 @@ var _ = Describe("ServiceInstanceDetails", func() {
 			err := store.StoreServiceInstanceDetails(storage.ServiceInstanceDetails{
 				GUID:             "fake-guid",
 				Name:             "fake-name",
-				Location:         "fake-location",
-				URL:              "fake-url",
 				Outputs:          map[string]any{"foo": "bar"},
 				ServiceGUID:      "fake-service-guid",
 				PlanGUID:         "fake-plan-guid",
@@ -29,8 +27,6 @@ var _ = Describe("ServiceInstanceDetails", func() {
 			Expect(db.Find(&receiver).Error).NotTo(HaveOccurred())
 			Expect(receiver.ID).To(Equal("fake-guid"))
 			Expect(receiver.Name).To(Equal("fake-name"))
-			Expect(receiver.Location).To(Equal("fake-location"))
-			Expect(receiver.URL).To(Equal("fake-url"))
 			Expect(receiver.OtherDetails).To(Equal([]byte(`{"encrypted":{"foo":"bar"}}`)))
 			Expect(receiver.ServiceID).To(Equal("fake-service-guid"))
 			Expect(receiver.PlanID).To(Equal("fake-plan-guid"))
@@ -56,8 +52,6 @@ var _ = Describe("ServiceInstanceDetails", func() {
 				err := store.StoreServiceInstanceDetails(storage.ServiceInstanceDetails{
 					GUID:             "fake-id-1",
 					Name:             "fake-name",
-					Location:         "fake-location",
-					URL:              "fake-url",
 					Outputs:          map[string]any{"foo": "bar"},
 					ServiceGUID:      "fake-service-guid",
 					PlanGUID:         "fake-plan-guid",
@@ -70,8 +64,6 @@ var _ = Describe("ServiceInstanceDetails", func() {
 				Expect(db.Where(`id = "fake-id-1"`).Find(&receiver).Error).NotTo(HaveOccurred())
 				Expect(receiver.ID).To(Equal("fake-id-1"))
 				Expect(receiver.Name).To(Equal("fake-name"))
-				Expect(receiver.Location).To(Equal("fake-location"))
-				Expect(receiver.URL).To(Equal("fake-url"))
 				Expect(receiver.OtherDetails).To(Equal([]byte(`{"encrypted":{"foo":"bar"}}`)))
 				Expect(receiver.ServiceID).To(Equal("fake-service-guid"))
 				Expect(receiver.PlanID).To(Equal("fake-plan-guid"))
@@ -91,8 +83,6 @@ var _ = Describe("ServiceInstanceDetails", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(r.GUID).To(Equal("fake-id-2"))
-			Expect(r.Location).To(Equal("fake-location-2"))
-			Expect(r.URL).To(Equal("fake-url-2"))
 			Expect(r.Outputs).To(Equal(storage.JSONObject{"decrypted": map[string]any{"foo": "bar-2"}}))
 			Expect(r.ServiceGUID).To(Equal("fake-service-id-2"))
 			Expect(r.PlanGUID).To(Equal("fake-plan-id-2"))
@@ -194,8 +184,6 @@ func addFakeServiceInstanceDetails() {
 	Expect(db.Create(&models.ServiceInstanceDetails{
 		ID:               "fake-id-1",
 		Name:             "fake-name-1",
-		Location:         "fake-location-1",
-		URL:              "fake-url-1",
 		OtherDetails:     []byte(`{"foo":"bar-1"}`),
 		ServiceID:        "fake-service-id-1",
 		PlanID:           "fake-plan-id-1",
@@ -205,8 +193,6 @@ func addFakeServiceInstanceDetails() {
 	Expect(db.Create(&models.ServiceInstanceDetails{
 		ID:               "fake-id-2",
 		Name:             "fake-name-2",
-		Location:         "fake-location-2",
-		URL:              "fake-url-2",
 		OtherDetails:     []byte(`{"foo":"bar-2"}`),
 		ServiceID:        "fake-service-id-2",
 		PlanID:           "fake-plan-id-2",
@@ -216,8 +202,6 @@ func addFakeServiceInstanceDetails() {
 	Expect(db.Create(&models.ServiceInstanceDetails{
 		ID:               "fake-id-3",
 		Name:             "fake-name-3",
-		Location:         "fake-location-3",
-		URL:              "fake-url-3",
 		OtherDetails:     []byte(`{"foo":"bar-3"}`),
 		ServiceID:        "fake-service-id-3",
 		PlanID:           "fake-plan-id-3",


### PR DESCRIPTION
These fields are not used in the codebase, so we should get rid of them.

Because this follows on fast from https://github.com/cloudfoundry/cloud-service-broker/commit/eabd3d631efb9c27ceb763456a06f67c99016ca1, I've updated the migration in that commit rather than add a new migration. As long as they both go out in the same release, then no-one will be exposed to the intermediate state.