### PR TITLE
refactor: func NewWorkspace returns proper zero-values for empty function parameters

### DIFF
--- a/pkg/providers/tf/bind_test.go
+++ b/pkg/providers/tf/bind_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/cloudfoundry/cloud-service-broker/v2/dbservice/models"
 	"github.com/cloudfoundry/cloud-service-broker/v2/pkg/providers/tf/workspace/workspacefakes"
 
-	"github.com/cloudfoundry/cloud-service-broker/v2/pkg/providers/tf/workspace"
-
 	"github.com/cloudfoundry/cloud-service-broker/v2/internal/storage"
 	"github.com/cloudfoundry/cloud-service-broker/v2/pkg/providers/tf"
 	"github.com/cloudfoundry/cloud-service-broker/v2/pkg/providers/tf/executor"
@@ -89,9 +87,9 @@ var _ = Describe("Bind", func() {
 			Expect(actualWorkspace.Modules[0].Definition).To(Equal(fakeServiceDefinition.BindSettings.Template))
 			Expect(actualWorkspace.Modules[0].Definitions).To(Equal(fakeServiceDefinition.BindSettings.Templates))
 			Expect(actualWorkspace.Instances[0].Configuration).To(Equal(map[string]any{"username": "some-user"}))
-			Expect(actualWorkspace.Transformer.ParameterMappings).To(Equal([]workspace.ParameterMapping{}))
-			Expect(actualWorkspace.Transformer.ParametersToRemove).To(Equal([]string{}))
-			Expect(actualWorkspace.Transformer.ParametersToAdd).To(Equal([]workspace.ParameterMapping{}))
+			Expect(actualWorkspace.Transformer.ParameterMappings).To(BeZero())
+			Expect(actualWorkspace.Transformer.ParametersToRemove).To(BeZero())
+			Expect(actualWorkspace.Transformer.ParametersToAdd).To(BeZero())
 
 			By("checking that provision is marked as started")
 			Expect(fakeDeploymentManager.MarkOperationStartedCallCount()).To(Equal(1))

--- a/pkg/providers/tf/deployment_manager_test.go
+++ b/pkg/providers/tf/deployment_manager_test.go
@@ -434,11 +434,6 @@ var _ = Describe("DeploymentManager", func() {
 							"resourceGroup": nil,
 						},
 					}},
-					Transformer: workspace.TfTransformer{
-						ParameterMappings:  []workspace.ParameterMapping{},
-						ParametersToRemove: []string{},
-						ParametersToAdd:    []workspace.ParameterMapping{},
-					},
 					State: []byte(terraformState),
 				}
 				Expect(actualTerraformDeployment.Workspace).To(Equal(expectedWorkspace))
@@ -515,11 +510,6 @@ var _ = Describe("DeploymentManager", func() {
 							"resourceGroup": nil,
 						},
 					}},
-					Transformer: workspace.TfTransformer{
-						ParameterMappings:  []workspace.ParameterMapping{},
-						ParametersToRemove: []string{},
-						ParametersToAdd:    []workspace.ParameterMapping{},
-					},
 					State: []byte(terraformState),
 				}
 				Expect(actualTerraformDeployment.Workspace).To(Equal(expectedWorkspace))

--- a/pkg/providers/tf/deployment_manager_test.go
+++ b/pkg/providers/tf/deployment_manager_test.go
@@ -424,9 +424,8 @@ var _ = Describe("DeploymentManager", func() {
 				By("checking that the modules and instances are updated, but the state remains the same")
 				expectedWorkspace := &workspace.TerraformWorkspace{
 					Modules: []workspace.ModuleDefinition{{
-						Name:        "brokertemplate",
-						Definition:  template,
-						Definitions: map[string]string{},
+						Name:       "brokertemplate",
+						Definition: template,
 					}},
 					Instances: []workspace.ModuleInstance{{
 						ModuleName:   "brokertemplate",
@@ -506,9 +505,8 @@ var _ = Describe("DeploymentManager", func() {
 				By("checking that the modules and instances are updated, but the state remains the same")
 				expectedWorkspace := &workspace.TerraformWorkspace{
 					Modules: []workspace.ModuleDefinition{{
-						Name:        "brokertemplate",
-						Definition:  template,
-						Definitions: map[string]string{},
+						Name:       "brokertemplate",
+						Definition: template,
 					}},
 					Instances: []workspace.ModuleInstance{{
 						ModuleName:   "brokertemplate",

--- a/pkg/providers/tf/provision_test.go
+++ b/pkg/providers/tf/provision_test.go
@@ -79,9 +79,9 @@ var _ = Describe("Provision", func() {
 			Expect(actualWorkspace.Modules[0].Definition).To(Equal(fakeServiceDefinition.ProvisionSettings.Template))
 			Expect(actualWorkspace.Modules[0].Definitions).To(Equal(fakeServiceDefinition.ProvisionSettings.Templates))
 			Expect(actualWorkspace.Instances[0].Configuration).To(Equal(map[string]any{"username": "some-user"}))
-			Expect(actualWorkspace.Transformer.ParameterMappings).To(Equal([]workspace.ParameterMapping{}))
-			Expect(actualWorkspace.Transformer.ParametersToRemove).To(Equal([]string{}))
-			Expect(actualWorkspace.Transformer.ParametersToAdd).To(Equal([]workspace.ParameterMapping{}))
+			Expect(actualWorkspace.Transformer.ParameterMappings).To(BeZero())
+			Expect(actualWorkspace.Transformer.ParametersToRemove).To(BeZero())
+			Expect(actualWorkspace.Transformer.ParametersToAdd).To(BeZero())
 
 			By("checking that provision is marked as started")
 			Expect(fakeDeploymentManager.MarkOperationStartedCallCount()).To(Equal(1))

--- a/pkg/providers/tf/workspace/workspace.go
+++ b/pkg/providers/tf/workspace/workspace.go
@@ -56,8 +56,11 @@ func NewWorkspace(templateVars map[string]any,
 	parametersToRemove []string,
 	parametersToAdd []ParameterMapping) (*TerraformWorkspace, error) {
 
-	terraformTemplatesCopy := make(map[string]string)
-	maps.Copy(terraformTemplatesCopy, terraformTemplates)
+	var terraformTemplatesCopy map[string]string
+	if len(terraformTemplates) > 0 {
+		terraformTemplatesCopy = make(map[string]string)
+		maps.Copy(terraformTemplatesCopy, terraformTemplates)
+	}
 
 	tfModule := ModuleDefinition{
 		Name:        "brokertemplate",
@@ -75,12 +78,23 @@ func NewWorkspace(templateVars map[string]any,
 		limitedConfig[name] = templateVars[name]
 	}
 
-	parameterMappingsCopy := make([]ParameterMapping, len(importParameterMappings))
-	copy(parameterMappingsCopy, importParameterMappings)
-	parametersToRemoveCopy := make([]string, len(parametersToRemove))
-	copy(parametersToRemoveCopy, parametersToRemove)
-	parametersToAddCopy := make([]ParameterMapping, len(parametersToAdd))
-	copy(parametersToAddCopy, parametersToAdd)
+	var parameterMappingsCopy []ParameterMapping
+	if len(importParameterMappings) > 0 {
+		parameterMappingsCopy = make([]ParameterMapping, len(importParameterMappings))
+		copy(parameterMappingsCopy, importParameterMappings)
+	}
+
+	var parametersToRemoveCopy []string
+	if len(parametersToRemove) > 0 {
+		parametersToRemoveCopy = make([]string, len(parametersToRemove))
+		copy(parametersToRemoveCopy, parametersToRemove)
+	}
+
+	var parametersToAddCopy []ParameterMapping
+	if len(parametersToAdd) > 0 {
+		parametersToAddCopy = make([]ParameterMapping, len(parametersToAdd))
+		copy(parametersToAddCopy, parametersToAdd)
+	}
 
 	workspace := TerraformWorkspace{
 		Modules: []ModuleDefinition{tfModule},

--- a/pkg/providers/tf/workspace/workspace_test.go
+++ b/pkg/providers/tf/workspace/workspace_test.go
@@ -370,4 +370,76 @@ func TestNewWorkspace(t *testing.T) {
 			t.Error("Expected NewWorkspace to create deep copy of ParametersToAdd")
 		}
 	})
+	t.Run("returns empty map for empty templateVars", func(t *testing.T) {
+		ws, err := NewWorkspace(nil, "", nil, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		got := ws.Instances[0].Configuration
+		expect := make(map[string]any)
+		if !reflect.DeepEqual(expect, got) {
+			t.Errorf("expected %v, got %v", expect, got)
+		}
+	})
+
+	t.Run("returns zero-value for empty terraformTemplate", func(t *testing.T) {
+		ws, err := NewWorkspace(nil, "", nil, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		got := ws.Modules[0].Definition
+		var expect string
+		if !reflect.DeepEqual(expect, got) {
+			t.Errorf("expected %v, got %v", expect, got)
+		}
+	})
+
+	t.Run("returns zero-value for empty terraformTemplates", func(t *testing.T) {
+		ws, err := NewWorkspace(nil, "", nil, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		got := ws.Modules[0].Definitions
+		var expect map[string]string
+		if !reflect.DeepEqual(expect, got) {
+			t.Errorf("expected %v, got %v", expect, got)
+		}
+	})
+
+	t.Run("returns zero-value for empty importParameterMappings", func(t *testing.T) {
+		ws, err := NewWorkspace(nil, "", nil, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		got := ws.Transformer.ParameterMappings
+		var expect []ParameterMapping
+		if !reflect.DeepEqual(expect, got) {
+			t.Errorf("expected %v, got %v", expect, got)
+		}
+	})
+
+	t.Run("returns zero-value for empty importParametersToRemove", func(t *testing.T) {
+		ws, err := NewWorkspace(nil, "", nil, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		got := ws.Transformer.ParametersToRemove
+		var expect []string
+		if !reflect.DeepEqual(expect, got) {
+			t.Errorf("expected %v, got %v", expect, got)
+		}
+	})
+
+	t.Run("returns zero-value for empty importParametersToAdd", func(t *testing.T) {
+		ws, err := NewWorkspace(nil, "", nil, nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		got := ws.Transformer.ParametersToAdd
+		var expect []ParameterMapping
+		if !reflect.DeepEqual(expect, got) {
+			t.Errorf("expected %v, got %v", expect, got)
+		}
+	})
+
 }


### PR DESCRIPTION
Func NewWorkspace returns proper go zero-values for each function parameter that is empty. 

This PR fixes unintended changes in the behavior of func NewWorkspace due to #1102 and causes the function to keep the principle of least confusion:

- #1102 changed the values which are returned in case the function parameters `terraformTemplates`, `importParameterMappings`, `parametersToRemove` and `parametersToAdd` are empty. This PR reverts this behaviour and keeps backwards-compability
- fixes failed tests in #1102 
- reverts #1114 

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

