### PR TITLE
fix: ParseVcapServices stops searching after the first service offering

### DIFF
--- a/dbservice/vcap.go
+++ b/dbservice/vcap.go
@@ -100,15 +100,16 @@ func ParseVcapServices(vcapServicesData string) (VcapService, error) {
 		return VcapService{}, fmt.Errorf("error unmarshalling VCAP_SERVICES: %s", err)
 	}
 
-	for _, vcapArray := range vcapMap {
-		vcapService, err := findMySQLTag(vcapArray, "mysql")
-		if err != nil {
-			return VcapService{}, fmt.Errorf("error finding MySQL tag: %s", err)
-		}
-		return vcapService, nil
+	flatVCAPServices := []VcapService{}
+	for _, v := range vcapMap {
+		flatVCAPServices = append(flatVCAPServices, v...)
 	}
 
-	return VcapService{}, fmt.Errorf("error parsing VCAP_SERVICES")
+	service, err := findMySQLTag(flatVCAPServices, "mysql")
+	if err != nil {
+		return VcapService{}, fmt.Errorf("error finding MySQL tag: %s", err)
+	}
+	return service, nil
 }
 
 // whether a given string array arr contains string key

--- a/dbservice/vcap_test.go
+++ b/dbservice/vcap_test.go
@@ -224,6 +224,79 @@ var _ = Describe("VCAP", func() {
 `)
 			Expect(err).To(MatchError("error finding MySQL tag: the variable VCAP_SERVICES must have one VCAP service with a tag of 'mysql'. There are currently 0 VCAP services with the tag 'mysql'"))
 		})
+
+		It("succeeds when VCAP_SERVICES has multiple lists but only one with a MySQL tag", func() {
+			_, err := ParseVcapServices(`{
+  "google-cloudsql-mysql": [
+    {
+      "binding_name": "testbinding",
+      "instance_name": "testinstance",
+      "name": "kf-binding-tt2-mystorage",
+      "label": "google-storage",
+      "tags": [
+        "gcp",
+        "cloudsql"
+      ],
+      "plan": "nearline",
+      "credentials": {
+				"CaCert": "-truncated-",
+				"ClientCert": "-truncated-",
+				"ClientKey": "-truncated-",
+				"Email": "pcf-binding-testbind@test-gsb.iam.gserviceaccount.com",
+        "Name": "pcf-binding-testbind",
+        "Password": "PASSWORD",
+        "PrivateKeyData": "PRIVATEKEY",
+        "ProjectId": "test-gsb",
+        "Sha1Fingerprint": "aa3bade266136f733642ebdb4992b89eb05f83c4",
+        "UniqueId": "108868434450972082663",
+        "UriPrefix": "",
+        "Username": "newuseraccount",
+        "database_name": "service_broker",
+        "host": "127.0.0.1",
+        "instance_name": "pcf-sb-1-1561406852899716453",
+        "last_master_operation_id": "",
+        "region": "",
+        "uri": "mysql://newuseraccount:PASSWORD@127.0.0.1/service_broker?ssl_mode=required"
+      }
+    }
+  ],
+  "user-provided": [
+  	{
+      "binding_name": "testbinding",
+      "instance_name": "testinstance",
+      "name": "kf-binding-tt2-mystorage",
+      "label": "google-storage",
+      "tags": [
+        "gcp",
+        "cloudsql",
+        "mysql"
+      ],
+      "plan": "nearline",
+      "credentials": {
+				"CaCert": "-truncated-",
+				"ClientCert": "-truncated-",
+				"ClientKey": "-truncated-",
+				"Email": "pcf-binding-testbind@test-gsb.iam.gserviceaccount.com",
+        "Name": "pcf-binding-testbind",
+        "Password": "PASSWORD",
+        "PrivateKeyData": "PRIVATEKEY",
+        "ProjectId": "test-gsb",
+        "Sha1Fingerprint": "aa3bade266136f733642ebdb4992b89eb05f83c4",
+        "UniqueId": "108868434450972082663",
+        "UriPrefix": "",
+        "Username": "newuseraccount",
+        "database_name": "service_broker",
+        "host": "127.0.0.1",
+        "instance_name": "pcf-sb-1-1561406852899716453",
+        "last_master_operation_id": "",
+        "region": "",
+        "uri": "mysql://newuseraccount:PASSWORD@127.0.0.1/service_broker?ssl_mode=required"
+      }
+    }
+  ]
+}`)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 
 	Describe("setting database credentials", func() {


### PR DESCRIPTION
The for loop on L103 was written to return after the checking the first entry in vcapMap, regardless of whether findMySQLTag found a suitable service or returned an error. If services from multiple service offerings are bound to the application and the service tagged with "mysql" is not in the first offering, the function will not find it. The new test case fails when run against the unmodified code.

To fix this, flatten the map[string][]VcapService into a []VCapService, and pass the flat slice to findMySQLTag.

### Checklist:

* [x] Have you added or updated tests to validate the changed functionality?
* [ ] Have you added Release Notes in the docs repositories?
* [x] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

