### PR TITLE
fix: use ca_cert instead of ca_cert_file

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -123,8 +123,7 @@ The broker supports passing credentials to apps via [credhub references](https:/
 | CH_UAA_CLIENT_NAME        |credhub.uaa_client_name| string | uaa username - usually `credhub_admin_client`|
 | CH_UAA_CLIENT_SECRET      |credhub.uaa_client_secret| string | uaa client secret - "*Credhub Admin Client Credentials*" from *Operations Manager > PAS > Credentials* tab. |
 | CH_SKIP_SSL_VALIDATION    |credhub.skip_ssl_validation| boolean | skip SSL validation if true | 
-| CH_CA_CERT_FILE           |credhub.ca_cert_file| path | path to cert file |
-
+| CH_CA_CERT                |credhub.ca_cert| string | CA cert |
 ### Credhub Config Example (Azure) 
 ```
 azure:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,7 @@ const (
 	credhubUaaClientName        = "credhub.uaa_client_name"
 	credhubUaaClientSecret      = "credhub.uaa_client_secret"
 	credhubSkipSSLValidation    = "credhub.skip_ssl_validation"
-	credhubCaCertFile           = "credhub.ca_cert_file"
+	credhubCACert               = "credhub.ca_cert"
 	credhubStoreBindCredentials = "credhub.store_bind_credentials"
 )
 
@@ -35,8 +35,8 @@ type CredStoreConfig struct {
 	UaaClientName        string `mapstructure:"uaa_client_name"`
 	UaaClientSecret      string `mapstructure:"uaa_client_secret"`
 	SkipSSLValidation    bool   `mapstructure:"skip_ssl_validation"`
-	CaCertFile           string `mapstructure:"ca_cert_file"`
 	StoreBindCredentials bool   `mapstructure:"store_bind_credentials"`
+	CACert               string `mapstructure:"ca_cert"`
 }
 
 type Config struct {
@@ -50,8 +50,8 @@ func Parse() (*Config, error) {
 	viper.BindEnv(credhubUaaClientName, "CH_UAA_CLIENT_NAME")
 	viper.BindEnv(credhubUaaClientSecret, "CH_UAA_CLIENT_SECRET")
 	viper.BindEnv(credhubSkipSSLValidation, "CH_SKIP_SSL_VALIDATION")
-	viper.BindEnv(credhubCaCertFile, "CH_CA_CERT_FILE")
 	viper.BindEnv(credhubStoreBindCredentials, "CH_STORE_BIND_CREDENTIALS")
+	viper.BindEnv(credhubCACert, "CH_CA_CERT")
 
 	err := viper.Unmarshal(&c)
 	if err != nil {

--- a/pkg/credstore/credstore.go
+++ b/pkg/credstore/credstore.go
@@ -59,16 +59,8 @@ func NewCredhubStore(credStoreConfig *config.CredStoreConfig, logger lager.Logge
 		credhub.AuthURL(credStoreConfig.UaaURL),
 	}
 
-	if credStoreConfig.CaCertFile != "" {
-		dat, err := os.ReadFile(credStoreConfig.CaCertFile)
-		if err != nil {
-			return nil, err
-		}
-
-		if dat == nil {
-			return nil, fmt.Errorf("CredHub certificate is not valid: %s", credStoreConfig.CaCertFile)
-		}
-		options = append(options, credhub.CaCerts(string(dat)))
+	if credStoreConfig.CACert != "" {
+		options = append(options, credhub.CaCerts(credStoreConfig.CACert))
 	}
 
 	ch, err := credhub.New(credStoreConfig.CredHubURL, options...)

--- a/pkg/credstore/credstore_test.go
+++ b/pkg/credstore/credstore_test.go
@@ -17,7 +17,6 @@ package credstore_test
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
 
 	"code.cloudfoundry.org/lager/v3"
 	"github.com/cloudfoundry/cloud-service-broker/v2/pkg/config"
@@ -54,7 +53,7 @@ var _ = Describe("Credhub Store", func() {
 			UaaClientName:        "my-client",
 			UaaClientSecret:      "my-secret",
 			SkipSSLValidation:    true,
-			CaCertFile:           "",
+			CACert:               "",
 			StoreBindCredentials: false,
 		}
 		chStore, err := credstore.NewCredhubStore(credStoreConfig, logger)
@@ -72,7 +71,7 @@ var _ = Describe("Credhub Store", func() {
 	})
 
 	It("sanity check cert file (class under test is mostly just a wrapper", func() {
-		content := []byte(`-----BEGIN CERTIFICATE-----
+		content := `-----BEGIN CERTIFICATE-----
 MIICsDCCAZgCCQDi7u3xz4OO2TANBgkqhkiG9w0BAQsFADAaMRgwFgYDVQQDDA93
 d3cuZXhhbXBsZS5jb20wHhcNMTkxMDI0MTkyNzEyWhcNMjkxMDIxMTkyNzEyWjAa
 MRgwFgYDVQQDDA93d3cuZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IB
@@ -88,14 +87,7 @@ WiaQqAkK41aqRSDOzUV4worM5HEeFGmSowrLRJOk1Wf1EGw8fD51pO3Zl4hv+PxN
 /hSSD7b12tEf59WnppMDXEvXbVVUbc1bQKrUBdbqRRAIvdVXkQQVKd11JAcsTi/T
 DLgHJRgZ5Bkp6yhm2RRzuQeMbozry9wXJg9MN14aLjfUNkB08+BX7kDk4H7ZgQ4S
 GqdyaKP2/eZ04RHn1TYI/UGRnzk=
------END CERTIFICATE-----`)
-		tmpfile, err := os.CreateTemp("", ".pem")
-		Expect(err).NotTo(HaveOccurred())
-
-		_, err = tmpfile.Write(content)
-		Expect(err).NotTo(HaveOccurred())
-		err = tmpfile.Close()
-		Expect(err).NotTo(HaveOccurred())
+-----END CERTIFICATE-----`
 
 		credStoreConfig := &config.CredStoreConfig{
 			CredHubURL:           chTestServer.URL,
@@ -103,7 +95,7 @@ GqdyaKP2/eZ04RHn1TYI/UGRnzk=
 			UaaClientName:        "my-client",
 			UaaClientSecret:      "my-secret",
 			SkipSSLValidation:    true,
-			CaCertFile:           tmpfile.Name(),
+			CACert:               content,
 			StoreBindCredentials: false,
 		}
 		chStore, err := credstore.NewCredhubStore(credStoreConfig, logger)
@@ -119,7 +111,5 @@ GqdyaKP2/eZ04RHn1TYI/UGRnzk=
 		Expect(chRequest).NotTo(BeNil())
 		chRequest.ParseForm()
 		Expect(chRequest.Form["name"]).To(Equal([]string{"/foo/bar/baz"}))
-
-		os.Remove(tmpfile.Name())
 	})
 })


### PR DESCRIPTION
The Credhub `ca_cert_file` was not being generated during installation. Instead, the Ops Manager certificate was being included in an unexpected configuration key.

Previously, the broker app ran on Diego and utilized the Cloud Foundry certificate trust store (the Ops Manager CA certificate was located in the container’s /etc/cf-system-certificates path).

Now, the broker runs on its own VM without automatic injection of the Ops Manager root CA or CF trust store. Although ca_cert was present in the job configuration, the broker wasn’t utilizing it, leading to the following error: `tls: failed to verify certificate: x509: certificate signed by unknown authority.`

### Checklist:

* [ ] Have you added or updated tests to validate the changed functionality?
* [ ] Have you added Release Notes in the docs repositories?
* [ ] Have you followed the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary)?

