### PR TITLE
chore: Revert go 1 24 features

### DIFF
--- a/.github/workflows/focused-test.yml
+++ b/.github/workflows/focused-test.yml
@@ -10,5 +10,5 @@ jobs:
         with:
           go-version: '1.23.6'
       - uses: actions/checkout@v4
-      - run: go tool ginkgo unfocus && test -z "$(git status -s)"
+      - run: go run github.com/onsi/ginkgo/v2/ginkgo unfocus && test -z "$(git status -s)"
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test-units: ## run unit tests
 # Integration tests are relatively resource-hungry, so we tune down the number of processes that run in parallel
 .PHONY: test-integration
 test-integration: .pak-cache ## run integration tests
-	PAK_BUILD_CACHE_PATH=$(PAK_CACHE) go tool ginkgo --procs 4 integrationtest/...
+	PAK_BUILD_CACHE_PATH=$(PAK_CACHE) go run github.com/onsi/ginkgo/v2/ginkgo --procs 4 integrationtest/...
 
 .pak-cache:
 	mkdir -p $(PAK_CACHE)

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ checkformat: ## Checks that the code is formatted correctly
 	fi
 
 checkimports: ## Checks that imports are formatted correctly
-	@@if [ -n "$$(go tool goimports -l -d .)" ]; then \
+	@@if [ -n "$$(go run golang.org/x/tools/cmd/goimports -l -d .)" ]; then \
 		echo "goimports check failed: run 'make format'";                      \
 		exit 1;                                                                \
 	fi
@@ -116,14 +116,14 @@ vet: ## Runs go vet
 	go vet ./...
 
 staticcheck: ## Runs staticcheck
-	go list ./... | grep -v 'fakes$$' | xargs go tool staticcheck
+	go list ./... | grep -v 'fakes$$' | xargs go run honnef.co/go/tools/cmd/staticcheck
 
 ###### Format #################################################################
 
 .PHONY: format
 format: ## format the source
 	gofmt -s -e -l -w .
-	go tool goimports -l -w .
+	go run golang.org/x/tools/cmd/goimports -l -w .
 
 ###### Image ##################################################################
 

--- a/go.mod
+++ b/go.mod
@@ -28,10 +28,12 @@ require (
 	github.com/zclconf/go-cty v1.16.2
 	golang.org/x/crypto v0.33.0
 	golang.org/x/net v0.35.0
+	golang.org/x/tools v0.30.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.5.7
 	gorm.io/driver/sqlite v1.5.7
 	gorm.io/gorm v1.25.12
+	honnef.co/go/tools v0.6.0
 )
 
 require (
@@ -130,7 +132,6 @@ require (
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
-	golang.org/x/tools v0.30.0 // indirect
 	google.golang.org/api v0.219.0 // indirect
 	google.golang.org/genproto v0.0.0-20250127172529-29210b9bc287 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250127172529-29210b9bc287 // indirect
@@ -139,12 +140,7 @@ require (
 	google.golang.org/protobuf v1.36.4 // indirect
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	honnef.co/go/tools v0.6.0 // indirect
 	rsc.io/goversion v1.2.0 // indirect
 )
 
-tool (
-	github.com/onsi/ginkgo/v2/ginkgo
-	golang.org/x/tools/cmd/goimports
-	honnef.co/go/tools/cmd/staticcheck
-)
+tool github.com/onsi/ginkgo/v2/ginkgo

--- a/go.mod
+++ b/go.mod
@@ -142,5 +142,3 @@ require (
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	rsc.io/goversion v1.2.0 // indirect
 )
-
-tool github.com/onsi/ginkgo/v2/ginkgo

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -6,6 +6,8 @@ package tools
 import (
 	_ "github.com/google/gops"
 	_ "github.com/maxbrunsfeld/counterfeiter/v6"
+	_ "golang.org/x/tools/cmd/goimports"
+	_ "honnef.co/go/tools/cmd/staticcheck"
 )
 
 // This file imports packages that are used when running go generate, or used

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -6,6 +6,7 @@ package tools
 import (
 	_ "github.com/google/gops"
 	_ "github.com/maxbrunsfeld/counterfeiter/v6"
+	_ "github.com/onsi/ginkgo/v2/ginkgo"
 	_ "golang.org/x/tools/cmd/goimports"
 	_ "honnef.co/go/tools/cmd/staticcheck"
 )


### PR DESCRIPTION
https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.87.0 is incompatible with 1.24
Until a version is released that fixes 1.24 compatibility issues, cloud-service-broker will use 1.23.6.
This reverts changes to make use of 1.24 features.
