### PR TITLE
chore: removed unused config property CH_STORE_BIND_CREDENTIALS

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,23 +20,21 @@ import (
 )
 
 const (
-	credhubURL                  = "credhub.url"
-	credhubUaaURL               = "credhub.uaa_url"
-	credhubUaaClientName        = "credhub.uaa_client_name"
-	credhubUaaClientSecret      = "credhub.uaa_client_secret"
-	credhubSkipSSLValidation    = "credhub.skip_ssl_validation"
-	credhubCACert               = "credhub.ca_cert"
-	credhubStoreBindCredentials = "credhub.store_bind_credentials"
+	credhubURL               = "credhub.url"
+	credhubUaaURL            = "credhub.uaa_url"
+	credhubUaaClientName     = "credhub.uaa_client_name"
+	credhubUaaClientSecret   = "credhub.uaa_client_secret"
+	credhubSkipSSLValidation = "credhub.skip_ssl_validation"
+	credhubCACert            = "credhub.ca_cert"
 )
 
 type CredStoreConfig struct {
-	CredHubURL           string `mapstructure:"url"`
-	UaaURL               string `mapstructure:"uaa_url"`
-	UaaClientName        string `mapstructure:"uaa_client_name"`
-	UaaClientSecret      string `mapstructure:"uaa_client_secret"`
-	SkipSSLValidation    bool   `mapstructure:"skip_ssl_validation"`
-	StoreBindCredentials bool   `mapstructure:"store_bind_credentials"`
-	CACert               string `mapstructure:"ca_cert"`
+	CredHubURL        string `mapstructure:"url"`
+	UaaURL            string `mapstructure:"uaa_url"`
+	UaaClientName     string `mapstructure:"uaa_client_name"`
+	UaaClientSecret   string `mapstructure:"uaa_client_secret"`
+	SkipSSLValidation bool   `mapstructure:"skip_ssl_validation"`
+	CACert            string `mapstructure:"ca_cert"`
 }
 
 type Config struct {
@@ -50,7 +48,6 @@ func Parse() (*Config, error) {
 	viper.BindEnv(credhubUaaClientName, "CH_UAA_CLIENT_NAME")
 	viper.BindEnv(credhubUaaClientSecret, "CH_UAA_CLIENT_SECRET")
 	viper.BindEnv(credhubSkipSSLValidation, "CH_SKIP_SSL_VALIDATION")
-	viper.BindEnv(credhubStoreBindCredentials, "CH_STORE_BIND_CREDENTIALS")
 	viper.BindEnv(credhubCACert, "CH_CA_CERT")
 
 	err := viper.Unmarshal(&c)

--- a/pkg/credstore/credstore_test.go
+++ b/pkg/credstore/credstore_test.go
@@ -48,13 +48,12 @@ var _ = Describe("Credhub Store", func() {
 
 	It("sanity check (class under test is mostly just a wrapper)", func() {
 		credStoreConfig := &config.CredStoreConfig{
-			CredHubURL:           chTestServer.URL,
-			UaaURL:               uaaTestServer.URL,
-			UaaClientName:        "my-client",
-			UaaClientSecret:      "my-secret",
-			SkipSSLValidation:    true,
-			CACert:               "",
-			StoreBindCredentials: false,
+			CredHubURL:        chTestServer.URL,
+			UaaURL:            uaaTestServer.URL,
+			UaaClientName:     "my-client",
+			UaaClientSecret:   "my-secret",
+			SkipSSLValidation: true,
+			CACert:            "",
 		}
 		chStore, err := credstore.NewCredhubStore(credStoreConfig, logger)
 		Expect(err).To(BeNil())
@@ -90,13 +89,12 @@ GqdyaKP2/eZ04RHn1TYI/UGRnzk=
 -----END CERTIFICATE-----`
 
 		credStoreConfig := &config.CredStoreConfig{
-			CredHubURL:           chTestServer.URL,
-			UaaURL:               uaaTestServer.URL,
-			UaaClientName:        "my-client",
-			UaaClientSecret:      "my-secret",
-			SkipSSLValidation:    true,
-			CACert:               content,
-			StoreBindCredentials: false,
+			CredHubURL:        chTestServer.URL,
+			UaaURL:            uaaTestServer.URL,
+			UaaClientName:     "my-client",
+			UaaClientSecret:   "my-secret",
+			SkipSSLValidation: true,
+			CACert:            content,
 		}
 		chStore, err := credstore.NewCredhubStore(credStoreConfig, logger)
 


### PR DESCRIPTION
The property can be read in from the environment, but it's never used in the code so has no effect.