### PR TITLE
chore: fix Markdown lint check

### DIFF
--- a/.github/workflows/mlc-config.json
+++ b/.github/workflows/mlc-config.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "opensource.org/license/apache-2"
+    },
+    {
+      "pattern": "github.com/cloudfoundry/cloud-service-broker/search"
     }
   ]
 }


### PR DESCRIPTION
For one particular link that results in a GitHub search we are consistently getting HTTP 429 (too many requests) when checking the link in CI, but it works perfectly when run outside of CI. Our assumption is that it's rate limiting by GitHub - probably due to all the other jobs running on the same GitHub Actions worker. If we skip that particular link, we can still check the others.