### PR TITLE
chore: ability to parse credential_client_id from binding details

### DIFF
--- a/internal/paramparser/parse_bind_details.go
+++ b/internal/paramparser/parse_bind_details.go
@@ -8,12 +8,13 @@ import (
 )
 
 type BindDetails struct {
-	AppGUID        string
-	PlanID         string
-	ServiceID      string
-	BindAppGUID    string
-	RequestParams  map[string]any
-	RequestContext map[string]any
+	AppGUID            string
+	CredentialClientID string
+	PlanID             string
+	ServiceID          string
+	BindAppGUID        string
+	RequestParams      map[string]any
+	RequestContext     map[string]any
 }
 
 func ParseBindDetails(input domain.BindDetails) (BindDetails, error) {
@@ -25,6 +26,7 @@ func ParseBindDetails(input domain.BindDetails) (BindDetails, error) {
 
 	if input.BindResource != nil {
 		result.BindAppGUID = input.BindResource.AppGuid
+		result.CredentialClientID = input.BindResource.CredentialClientID
 	}
 
 	if len(input.RawParameters) > 0 {

--- a/internal/paramparser/parse_bind_details_test.go
+++ b/internal/paramparser/parse_bind_details_test.go
@@ -15,7 +15,8 @@ var _ = Describe("ParseBindDetails", func() {
 			PlanID:    "fake-plan-id",
 			ServiceID: "fake-service-id",
 			BindResource: &domain.BindResource{
-				AppGuid: "fake-bind-app-guid",
+				AppGuid:            "fake-bind-app-guid",
+				CredentialClientID: "fake-credential-client-id",
 			},
 			RawContext:    []byte(`{"foo": "bar"}`),
 			RawParameters: []byte(`{"baz": "quz"}`),
@@ -25,12 +26,13 @@ var _ = Describe("ParseBindDetails", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(bindDetails).To(Equal(paramparser.BindDetails{
-			AppGUID:        "fake-app-guid",
-			PlanID:         "fake-plan-id",
-			ServiceID:      "fake-service-id",
-			BindAppGUID:    "fake-bind-app-guid",
-			RequestParams:  map[string]any{"baz": "quz"},
-			RequestContext: map[string]any{"foo": "bar"},
+			AppGUID:            "fake-app-guid",
+			CredentialClientID: "fake-credential-client-id",
+			PlanID:             "fake-plan-id",
+			ServiceID:          "fake-service-id",
+			BindAppGUID:        "fake-bind-app-guid",
+			RequestParams:      map[string]any{"baz": "quz"},
+			RequestContext:     map[string]any{"foo": "bar"},
 		}))
 	})
 
@@ -44,9 +46,10 @@ var _ = Describe("ParseBindDetails", func() {
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bindDetails).To(Equal(paramparser.BindDetails{
-				AppGUID:   "fake-app-guid",
-				PlanID:    "fake-plan-id",
-				ServiceID: "fake-service-id",
+				AppGUID:            "fake-app-guid",
+				PlanID:             "fake-plan-id",
+				ServiceID:          "fake-service-id",
+				CredentialClientID: "",
 			}))
 		})
 	})


### PR DESCRIPTION
This is provided by CF when there is no app guid