### PR TITLE
chore: binding has only one App GUID

### DIFF
--- a/internal/paramparser/parse_bind_details.go
+++ b/internal/paramparser/parse_bind_details.go
@@ -12,7 +12,6 @@ type BindDetails struct {
 	CredentialClientID string
 	PlanID             string
 	ServiceID          string
-	BindAppGUID        string
 	RequestParams      map[string]any
 	RequestContext     map[string]any
 }
@@ -25,7 +24,7 @@ func ParseBindDetails(input domain.BindDetails) (BindDetails, error) {
 	}
 
 	if input.BindResource != nil {
-		result.BindAppGUID = input.BindResource.AppGuid
+		result.AppGUID = input.BindResource.AppGuid
 		result.CredentialClientID = input.BindResource.CredentialClientID
 	}
 

--- a/pkg/broker/service_definition.go
+++ b/pkg/broker/service_definition.go
@@ -507,7 +507,7 @@ func (svc *ServiceDefinition) BindVariables(instance storage.ServiceInstanceDeta
 		// the duplicate sending of fields is likely to be removed.
 		"request.plan_id":         instance.PlanGUID,
 		"request.service_id":      instance.ServiceGUID,
-		"request.app_guid":        details.BindAppGUID,
+		"request.app_guid":        details.AppGUID,
 		"request.plan_properties": plan.GetServiceProperties(),
 
 		// specified by the existing instance


### PR DESCRIPTION
In OSBAPI, the "app_guid" field in the request has been deprecated in favour of "bind_resource.app_guid". We have been treating these as separate GUIDs when in fact they are the same thing appearing in different locations.