### PR TITLE
chore: allow log level to be set via CSB_LOG_LEVEL

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -94,6 +94,8 @@ Values for debugging:
 | Environment Variable                   | Config File Value         | Type | Description                                                                                     |
 |----------------------------------------|---------------------------|------|-------------------------------------------------------------------------------------------------|
 | <tt>CSB_DEBUG_LEAVE_WORKSPACE_DIR</tt> | debug.leave_workspace_dir | bool | Disables the cleanup of workspace directories, so you can inspect the files and run tf commands |
+| <tt>CSB_LOG_LEVEL</tt> | (none) | string | Sets the logging level to the specified value, which can be one of `debug`, `info`, `error`, `fatal` |
+| <tt>GSB_DEBUG</tt> | (none) | bool | If set to any value, the log level is set to `debug`. Overrides `CSB_LOG_LEVEL` |
 
 ## Feature flags Configuration
 

--- a/internal/local/environment.go
+++ b/internal/local/environment.go
@@ -10,7 +10,7 @@ import (
 )
 
 func passThroughEnvs() []string {
-	result := append(manifestAllowedEnvs(), "TF_LOG", "TF_LOG_CORE", "TF_LOG_PROVIDER", "TF_LOG_PATH")
+	result := append(manifestAllowedEnvs(), "TF_LOG", "TF_LOG_CORE", "TF_LOG_PROVIDER", "TF_LOG_PATH", "CSB_LOG_LEVEL")
 	result = append(result, featureflags.AllFeatureFlagEnvVars...)
 	return result
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -138,8 +138,19 @@ func SingleLineErrorFormatter(es []error) string {
 // writing settings.
 func NewLogger(name string) lager.Logger {
 	logger := lager.NewLogger(name)
+	logLevel := lager.INFO // default
 
-	logLevel := lager.INFO
+	// Can use environment variable CSB_LOG_LEVEL to set the level.
+	// If the value is invalid, we ignore it.
+	if level, ok := os.LookupEnv("CSB_LOG_LEVEL"); ok {
+		parsedLevel, err := lager.LogLevelFromString(level)
+		if err == nil {
+			logLevel = parsedLevel
+		}
+	}
+
+	// The GSB_DEBUG environment variable is the long-standing way
+	// to enable debug logging, and it overrides CSB_LOG_LEVEL
 	if _, debug := os.LookupEnv("GSB_DEBUG"); debug {
 		logLevel = lager.DEBUG
 	}


### PR DESCRIPTION
Exposes and documents the CSB_LOG_LEVEL environment variable to allow the Lager log level to be set.
